### PR TITLE
12 UI add support for platform urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ For instance, if we set the language preferences to `en-gb,en`, filtering `x.pro
 
 Language preferences do not apply if an explicit language tag is used: `x.property@en` will always get the `en`-tagged literals, and `x.property@` will always get the untagged literals.
 
+### Platform URL support
+
+Data and schema models can be loaded using Platform:/ URLs when using the driver in an Eclipse enviroment. All Platform URLs are converted to File URLs before being passed to Jena.
+
 ### Data models, schema models and reasoners
 
 RDF models are loaded as Ontology Resource Models with Jena's default OWL reasoner.

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/META-INF/MANIFEST.MF
@@ -3,6 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Developer Tools for Epsilon Model Connectivity RDF driver
 Bundle-SymbolicName: org.eclipse.epsilon.emc.rdf.dt;singleton:=true
 Bundle-Version: 1.0.0.qualifier
+Export-Package: org.eclipse.epsilon.emc.rdf.dt
 Require-Bundle: org.eclipse.epsilon.emc.rdf;bundle-version="1.0.0",
  org.eclipse.epsilon.common.dt;bundle-version="2.1.0"
 Bundle-Vendor: University of York

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/plugin.xml
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.epsilon.common.dt.modelType">
       <modelType
-            class="org.eclipse.epsilon.emc.rdf.RDFModel"
+            class="org.eclipse.epsilon.emc.rdf.dt.EclipseRDFModel"
             dialog="org.eclipse.epsilon.emc.rdf.dt.RDFModelConfigurationDialog"
             icon="icons/sw-cube.png"
             label="RDF Model"

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
@@ -1,0 +1,58 @@
+package org.eclipse.epsilon.emc.rdf.dt;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.epsilon.emc.rdf.RDFModel;
+import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
+
+public class EclipseRDFModel extends RDFModel {
+	
+	@Override
+	protected void loadModel() throws EolModelLoadingException { 
+		// Change any platform:/ URLs to file:/ URLs in these lists...
+		System.err.println("EclipseRDFModel");
+		schemaURIs.forEach(e -> System.out.println(e));
+		dataURIs.forEach(e -> System.out.println(e));
+		
+		examplePlatformToFile();
+		
+		// Call the RDFModel load as normal with File URLs
+		super.loadModel();
+		
+	}
+	
+	private static final String PLATFORM_URL_OWLDATA = "platform:/resource/org.eclipse.epsilon.examples.emc.rdf.OWLdata/owlDemoData.ttl";
+	private static final String PLATFORM_URL_OWLSCHEMA = "platform:/resource/org.eclipse.epsilon.examples.emc.rdf.OWLdata/owlDemoData.ttl";
+	
+	private void examplePlatformToFile() {
+		System.out.println(Platform.getLocation());
+		
+		URI fileUri = URI.create(PLATFORM_URL_OWLDATA);
+		
+		URL fileUrl = null;
+		try {
+			fileUrl = fileUri.toURL();
+				
+		} catch (MalformedURLException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		URL fileSystemPathUrl = null;		
+		try {
+			fileSystemPathUrl = FileLocator.toFileURL(fileUrl);
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		
+		
+		System.out.println("platform URL: " + PLATFORM_URL_OWLDATA);
+		System.out.println("PATH: " + fileSystemPathUrl);
+	}
+}

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.Platform;
@@ -15,16 +17,68 @@ public class EclipseRDFModel extends RDFModel {
 	@Override
 	protected void loadModel() throws EolModelLoadingException { 
 		// Change any platform:/ URLs to file:/ URLs in these lists...
-		System.err.println("EclipseRDFModel");
-		schemaURIs.forEach(e -> System.out.println(e));
-		dataURIs.forEach(e -> System.out.println(e));
+
+		processEclipsePlatformUrlsInList(schemaURIs);
+		processEclipsePlatformUrlsInList(dataURIs);
 		
-		examplePlatformToFile();
-		
-		// Call the RDFModel load as normal with File URLs
+		// Call the RDFModel load as normal with only File:/ URLs in the lists
 		super.loadModel();
-		
 	}
+	
+	// Pushes a list of URLs through a process to turn any Platform:/ into File:/ which Jena can use
+	private void processEclipsePlatformUrlsInList(List<String> urlList) {
+		List<String> goodUrls = new ArrayList<String>();
+		
+		urlList.forEach(u -> {
+			String newUrlString = processPlatformURLtoFileUrl(u);
+			if (newUrlString != null) {
+				goodUrls.add(newUrlString);
+			}
+		});
+		urlList.clear();
+		urlList.addAll(goodUrls);
+	}
+	
+
+	// Will attempt to resolve a String to a URI and then URL, gets the file system path and returns it
+	// A File:/ URL is unchanged by this process, Platform:/ URLs become File:/ URLs
+	private String processPlatformURLtoFileUrl(String urlString) {
+		
+		URI fileUri = URI.create(urlString);
+		
+		URL fileUrl = null;
+		try {
+			fileUrl = fileUri.toURL();		
+			// System.err.println("[OK] fileUrl: " + fileUrl);
+		} catch (MalformedURLException e) {
+			//e.printStackTrace();
+			System.err.println("fileUri.toURL() - " + urlString);
+		}
+		
+		URL fileSystemPathUrl = null;		
+		try {
+			fileSystemPathUrl = FileLocator.toFileURL(fileUrl);
+			// System.err.println("[OK] fileSystemPathUrl: " + fileSystemPathUrl);
+		} catch (IOException e) {
+			//e.printStackTrace();
+			System.err.println("FileLocator.toFileURL(fileUrl); - " + fileUrl);
+		}
+		
+		if (null != fileSystemPathUrl) {
+			return fileSystemPathUrl.toString();
+		} else {
+			return null;
+		}
+	}
+
+	// Handy way to show the lists on the console
+	private void showList (String listName, List<String> list) {
+		System.out.println(listName + ": ");
+		list.forEach(e -> System.out.println(e));
+	}
+	
+	
+	// Stuff to delete later
 	
 	private static final String PLATFORM_URL_OWLDATA = "platform:/resource/org.eclipse.epsilon.examples.emc.rdf.OWLdata/owlDemoData.ttl";
 	private static final String PLATFORM_URL_OWLSCHEMA = "platform:/resource/org.eclipse.epsilon.examples.emc.rdf.OWLdata/owlDemoData.ttl";
@@ -41,6 +95,7 @@ public class EclipseRDFModel extends RDFModel {
 		} catch (MalformedURLException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
+			System.err.println(readOnLoad);
 		}
 		
 		URL fileSystemPathUrl = null;		

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
@@ -37,11 +37,11 @@ public class EclipseRDFModel extends RDFModel {
 		urlList.addAll(goodUrls);
 	}	
 
-	// Will attempt to resolve a String to a URI and then URL, gets the file system path and returns it
-	// A File:/ URL is unchanged by this process, Platform:/ URLs become File:/ URLs
+	// A File:/ URL or relative path starting '/' or '.' is unchanged by this process, Platform:/ URLs become File:/ URLs
+	// Attempts to resolve a String to a URI and then URL, then gets the File:/ URL and returns it
 	private String processPlatformURLtoFileUrl(String urlString) throws EolModelLoadingException {
 
-		// Any URLS starting . / are possibly relative paths, they should work with Jena
+		// Any URLS starting . / are possibly relative paths, they should work with Jena if correct
 		if ((urlString.startsWith(".")) | (urlString.startsWith("/"))) {
 			return urlString;
 		}
@@ -58,9 +58,11 @@ public class EclipseRDFModel extends RDFModel {
 	}
 
 	// Handy way to show the lists on the console
+	/*
 	private void showList (String listName, List<String> list) {
 		System.out.println(listName + ": ");
 		list.forEach(e -> System.out.println(e));
 	}
+	*/
 
 }

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.epsilon.emc.rdf.RDFModel;
 import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
 

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
@@ -1,7 +1,5 @@
 package org.eclipse.epsilon.emc.rdf.dt;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/EclipseRDFModel.java
@@ -30,45 +30,30 @@ public class EclipseRDFModel extends RDFModel {
 				newUrlString = processPlatformURLtoFileUrl(u);
 				goodUrls.add(newUrlString);
 			} catch (EolModelLoadingException e) {
-				System.err.println(e);
+				// System.err.println(e);
 			}
 		});
 		urlList.clear();
 		urlList.addAll(goodUrls);
-	}
-	
+	}	
 
 	// Will attempt to resolve a String to a URI and then URL, gets the file system path and returns it
 	// A File:/ URL is unchanged by this process, Platform:/ URLs become File:/ URLs
 	private String processPlatformURLtoFileUrl(String urlString) throws EolModelLoadingException {
-		URI fileUri = URI.create(urlString);
-		
-		URL fileUrl = null;
-		try {
-			fileUrl = fileUri.toURL();		
-		} catch (Exception ex) {
-			throw new EolModelLoadingException(ex, this);
-		}
-		
-		// Only transform platform to file urls, return all others unchanged
-		if (fileUrl.getProtocol().contentEquals("platform"))
-		{
-			URL fileSystemPathUrl = null;		
-			try {
-				fileSystemPathUrl = FileLocator.toFileURL(fileUrl);
-			} catch (Exception ex) {
-				throw new EolModelLoadingException(ex, this);
-			}
-			
-			try {
-				return fileSystemPathUrl.toString();
-			} catch (Exception ex) {
-				throw new EolModelLoadingException(ex, this);	
-			}
-		}
-		else
-		{
+
+		// Any URLS starting . / are possibly relative paths, they should work with Jena
+		if ((urlString.startsWith(".")) | (urlString.startsWith("/"))) {
 			return urlString;
+		}
+
+		URI fileUri = URI.create(urlString);
+		try {
+			URL fileUrl = fileUri.toURL();
+			URL fileSystemPathUrl = FileLocator.toFileURL(fileUrl);
+			return fileSystemPathUrl.toString();
+		} catch (Exception ex) {
+			System.err.println("Error processing URL: " + urlString);
+			throw new EolModelLoadingException(ex, this);
 		}
 	}
 

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
@@ -155,11 +155,15 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		public String prefix, url;
 	}
 
+	private String getIFilePlatformAsUrlString(IFile file) {
+		// Is there a better way to convert the full path to a platform url?
+		return "platform:/resource" + file.getFullPath().toPortableString();
+	}
+	
 	protected class URLTableEntry {
 		public URLTableEntry(String url) {
 			this.url = url;
 		}
-
 		public String url;
 	}
 
@@ -317,11 +321,11 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		addFromWorkspaceButton.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
+				
 				IFile file = BrowseWorkspaceUtil.browseFile(getShell(),
-						"Browse workspace", "Select file with RDF content", "*.rdf", null);
-
+						"Browse workspace", "Select file with RDF content", "*.rdf", null);				
 				if (file != null) {
-					dataModelUrls.add(new URLTableEntry(file.getLocationURI().toString()));
+					dataModelUrls.add(new URLTableEntry(getIFilePlatformAsUrlString(file)));
 					dataModelUrlListViewer.refresh();
 				}
 			}
@@ -426,7 +430,7 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 						"Browse workspace", "Select file with RDF content", "*.rdf", null);
 
 				if (file != null) {
-					schemaModelUrls.add(new URLTableEntry(file.getLocationURI().toString()));
+					schemaModelUrls.add(new URLTableEntry(getIFilePlatformAsUrlString(file)));
 					schemaModelUrlListViewer.refresh();
 				}
 			}

--- a/examples/org.eclipse.epsilon.examples.emc.rdf.OWLdemodata/Run query on OWL demo data.launch
+++ b/examples/org.eclipse.epsilon.examples.emc.rdf.OWLdemodata/Run query on OWL demo data.launch
@@ -3,7 +3,7 @@
     <booleanAttribute key="fine_grained_profiling" value="false"/>
     <stringAttribute key="implementation_name" value="Parallel"/>
     <listAttribute key="models">
-        <listEntry value="aliases=aModel&#10;languagePreference=&#10;name=Model&#10;prefixes=&#10;schemaUris=file\:/home/hmz514/git/emc-rdf/examples/org.eclipse.epsilon.examples.emc.rdf.OWLdemodata/owlDemoSchema.ttl&#10;type=RDF&#10;uris=file\:/home/hmz514/git/emc-rdf/examples/org.eclipse.epsilon.examples.emc.rdf.OWLdemodata/owlDemoData.ttl"/>
+        <listEntry value="aliases=aModel&#10;languagePreference=&#10;name=Model&#10;prefixes=&#10;schemaUris=platform\:/resource/org.eclipse.epsilon.examples.emc.rdf.OWLdata/owlDemoSchema.ttl&#10;type=RDF&#10;uris=platform\:/resource/org.eclipse.epsilon.examples.emc.rdf.OWLdata/owlDemoData.ttl"/>
     </listAttribute>
     <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
     <intAttribute key="parallelism" value="7"/>

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/EclipseProjectEnvTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/EclipseProjectEnvTest.java
@@ -16,10 +16,12 @@ public class EclipseProjectEnvTest {
  * 
  * <p>
  * Note: all tests based on this class must run as JUnit Plug-In tests, not as
- * regular tests, and the ui.workbench product or Headless needs to be run. We need a
+ * regular tests, and the ui.workbench product (or Headless) needs to be run. We need a
  * working, open workbench for these tests.
  * </p>
  */
+	
+	private final int FILESYSTEM_SYNC_TIMEOUT_SECONDS = 10;
 	
 	private final String projectUrl;
 	
@@ -29,7 +31,7 @@ public class EclipseProjectEnvTest {
 	 * Creates a new project with this URL
 	 * 
 	 * @param projectUrl
-	 *            Project URL to use for a project resource in Eclipse IDE Workbench used for the test
+	 *            Project URL to use for a project resource in Eclipse IDE Workbench that the test will use
 	 */
 	public EclipseProjectEnvTest(String projectUrl) {
 		this.projectUrl = projectUrl;
@@ -46,8 +48,6 @@ public class EclipseProjectEnvTest {
 		}
 		testProject.create(null);
 		testProject.open(null);		
-		
-		//System.out.println("Test location URI: "+testProject.getLocationURI());		
 	}
 
 	@After
@@ -56,26 +56,23 @@ public class EclipseProjectEnvTest {
 		
 		int count = 0;
 		while (!testProject.isSynchronized(1)) {
-			count = checkTimeOut(count, 10,"Waiting for delete sync... ");			
+			count = checkTimeOut(count, FILESYSTEM_SYNC_TIMEOUT_SECONDS,"Waiting for delete sync... ");			
 		}
 	}
 	
 	public void copyIntoProject(String path) throws Exception {
-		//System.out.println("copyIntoProject() : "+path);
 		IFile destFile=null; 
 		try (InputStream source = getClass().getResourceAsStream(path)) {
 			destFile = testProject.getFile(new Path(path));
 			createParentFolders(destFile);
-			destFile.create(source, false, null);
-			//System.out.println("source: "+ path);
-			//System.out.println("destFile: "+ destFile.getFullPath());			
+			destFile.create(source, false, null);			
 		} catch (Exception e) {
 			System.out.println("ERROR: copyIntoProject() " +e);
 		}
 		if (null != destFile) {			
 			int count = 0;
 			while (!destFile.isSynchronized(1)) {	
-				count = checkTimeOut(count, 10,"Waiting for file sync");			
+				count = checkTimeOut(count, FILESYSTEM_SYNC_TIMEOUT_SECONDS,"Waiting for file sync");			
 			}
 		}
 	}

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/EclipseProjectEnvTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/EclipseProjectEnvTest.java
@@ -1,0 +1,124 @@
+package org.eclipse.epsilon.emc.rdf;
+
+import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.core.resources.*;
+import org.eclipse.core.runtime.Path;
+import org.junit.After;
+import org.junit.Before;
+public class EclipseProjectEnvTest {
+
+/**
+ * <p>
+ * Base class for tests requiring an Eclipse IDE project and workbench environment.
+ * </p>
+ * 
+ * <p>
+ * Note: all tests based on this class must run as JUnit Plug-In tests, not as
+ * regular tests, and the ui.workbench product or Headless needs to be run. We need a
+ * working, open workbench for these tests.
+ * </p>
+ */
+	
+	private final String projectUrl;
+	
+	private IProject testProject;
+
+	/**
+	 * Creates a new project with this URL
+	 * 
+	 * @param projectUrl
+	 *            Project URL to use for a project resource in Eclipse IDE Workbench used for the test
+	 */
+	public EclipseProjectEnvTest(String projectUrl) {
+		this.projectUrl = projectUrl;
+	}
+
+	@Before
+	public void createTestProject() throws Exception {
+		final IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		final IWorkspaceRoot root = workspace.getRoot();
+		
+		testProject = root.getProject(projectUrl);
+		if (testProject.exists()) {
+			deleteTestProject();
+		}
+		testProject.create(null);
+		testProject.open(null);		
+		
+		//System.out.println("Test location URI: "+testProject.getLocationURI());		
+	}
+
+	@After
+	public void deleteTestProject() throws Exception {
+		testProject.delete(true, true, null);
+		
+		int count = 0;
+		while (!testProject.isSynchronized(1)) {
+			count = checkTimeOut(count, 10,"Waiting for delete sync... ");			
+		}
+	}
+	
+	public void copyIntoProject(String path) throws Exception {
+		//System.out.println("copyIntoProject() : "+path);
+		IFile destFile=null; 
+		try (InputStream source = getClass().getResourceAsStream(path)) {
+			destFile = testProject.getFile(new Path(path));
+			createParentFolders(destFile);
+			destFile.create(source, false, null);
+			//System.out.println("source: "+ path);
+			//System.out.println("destFile: "+ destFile.getFullPath());			
+		} catch (Exception e) {
+			System.out.println("ERROR: copyIntoProject() " +e);
+		}
+		if (null != destFile) {			
+			int count = 0;
+			while (!destFile.isSynchronized(1)) {	
+				count = checkTimeOut(count, 10,"Waiting for file sync");			
+			}
+		}
+	}
+	
+	private static void createParentFolders(IResource res) throws Exception {
+		final IContainer parent = res.getParent();
+		if (parent instanceof IFolder) {
+			createParentFolders(parent);
+		}
+		if (res instanceof IFolder && !res.exists()) {
+			((IFolder) res).create(false, true, null);
+		}
+	}
+		
+	// Delays 1 second, set limit to X seconds you want to wait
+	private int checkTimeOut(int current, int limit, String errorLabel) throws Exception {
+		System.out.println(" - " + errorLabel + " Time out: " + current + "/" + limit );
+		if (current >= limit)
+		{
+			//System.err.println("Check time out error: " + errorLabel);	
+			throw new Exception("Check time out error: " + errorLabel);
+		}
+		delaySeconds(1);
+		return ++current;		
+	}
+	
+	private void delaySeconds(int seconds) {
+		try {
+			TimeUnit.SECONDS.sleep(seconds);
+		} catch (InterruptedException ie) {
+			Thread.currentThread().interrupt();
+		}
+	}
+	
+	public String getProjectUrl() {
+		return projectUrl;
+	}
+	
+	public String getTestProjectURIString() {
+		return testProject.getLocationURI().toString();
+	}
+
+	public IProject getTestProject() {
+		return testProject;
+	}
+}

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/EclipseRDFModelUrlTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/EclipseRDFModelUrlTest.java
@@ -13,11 +13,8 @@
 
 package org.eclipse.epsilon.emc.rdf;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 
 import org.eclipse.epsilon.common.util.StringProperties;
 import org.eclipse.epsilon.emc.rdf.dt.EclipseRDFModel;
@@ -45,6 +42,10 @@ public class EclipseRDFModelUrlTest extends EclipseProjectEnvTest {
 	private EclipseRDFModel model;
 	private EolContext context;
 
+	//
+	// NO ERRORS EXPECTED
+	//
+	
 	@Test
 	public void relativePathModelLoad() throws EolModelLoadingException {
 		String dataUrl = new String("." + OWL_DEMO_DATAMODEL);
@@ -94,26 +95,42 @@ public class EclipseRDFModelUrlTest extends EclipseProjectEnvTest {
 		loadedModelTest();
 	}
 
-	@Test(expected = EolModelLoadingException.class)
-	public void missingResourceInPlatformUrlModelLoad() throws EolModelLoadingException {
+	//
+	//  EXPECTED ERRORS!
+	//
+	
+	@Test
+	public void missingResourceInPlatformUrlModelLoad() {
 		String dataUrl = new String("platform:/-/" + PROJECT_URL + "/" + OWL_DEMO_DATAMODEL);
 		String schemaUrl = new String("platform:/-/" + PROJECT_URL + "/" + OWL_DEMO_SCHEMAMODEL);
 		StringProperties props = createPropertyString(dataUrl, schemaUrl, LANGUAGE_PREFERENCE_EN_STRING);
 
 		this.context = new EolContext();
 		copyModelFiles();
-		model.load(props);
+		
+		try {
+			model.load(props);
+		} catch (EolModelLoadingException e) {
+			System.err.println("Test internal message: " + e.getInternal().getMessage());
+			assertEquals("Error whilst loading model null: No file path has been set", e.getMessage());
+		}
 	}
 
-	@Test(expected = EolModelLoadingException.class)
-	public void missingProjectUrlInPlatformUrlModelLoad() throws EolModelLoadingException {
+	@Test
+	public void missingProjectUrlInPlatformUrlModelLoad() {
 		String dataUrl = new String("platform:/resource" + OWL_DEMO_DATAMODEL);
 		String schemaUrl = new String("platform:/resource" + OWL_DEMO_SCHEMAMODEL);
 		StringProperties props = createPropertyString(dataUrl, schemaUrl, LANGUAGE_PREFERENCE_EN_STRING);
 
 		this.context = new EolContext();
 		copyModelFiles();
-		model.load(props);
+		
+		try {
+			model.load(props);
+		} catch (EolModelLoadingException e) {
+			System.err.println("Test internal message: " + e.getInternal().getMessage());
+			assertEquals("Error whilst loading model null: No file path has been set",e.getMessage());
+		}
 	}
 
 	@After
@@ -147,7 +164,6 @@ public class EclipseRDFModelUrlTest extends EclipseProjectEnvTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
-		System.out.println("props: " + props.toString());
 		return props;
 	}
 }

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/EclipseRDFModelUrlTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/EclipseRDFModelUrlTest.java
@@ -1,0 +1,153 @@
+/********************************************************************************
+ * Copyright (c) 2024 University of York
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Antonio Garcia-Dominguez - initial API and implementation
+ ********************************************************************************/
+
+package org.eclipse.epsilon.emc.rdf;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import org.eclipse.epsilon.common.util.StringProperties;
+import org.eclipse.epsilon.emc.rdf.dt.EclipseRDFModel;
+import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
+import org.eclipse.epsilon.eol.execute.context.EolContext;
+import org.junit.After;
+import org.junit.Test;
+
+public class EclipseRDFModelUrlTest extends EclipseProjectEnvTest {
+
+	public EclipseRDFModelUrlTest() {
+		super(PROJECT_URL);
+	}
+
+	private static final String PROJECT_URL = "myProject";
+
+	private static final String OWL_DEMO_DATAMODEL = "/resources/OWL/owlDemoData.ttl";
+	private static final String OWL_DEMO_SCHEMAMODEL = "/resources/OWL/owlDemoSchema.ttl";
+	private static final String LANGUAGE_PREFERENCE_EN_STRING = "en";
+	
+	private static final String URI_BIGNAME42 = "urn:x-hp:eg/bigName42";
+	private static final String URI_ALIENBOX51 = "urn:x-hp:eg/alienBox51";
+	private static final String URI_WHITEBOX = "urn:x-hp:eg/whiteBoxZX";
+
+	private EclipseRDFModel model;
+	private EolContext context;
+
+	@Test
+	public void relativePathModelLoad() throws EolModelLoadingException {
+		String dataUrl = new String("." + OWL_DEMO_DATAMODEL);
+		String schemaUrl = new String("." + OWL_DEMO_SCHEMAMODEL);
+		StringProperties props = createPropertyString(dataUrl, schemaUrl, LANGUAGE_PREFERENCE_EN_STRING);
+
+		this.context = new EolContext();
+		copyModelFiles();
+		model.load(props);
+	}
+
+	@Test
+	public void relativeFileUrlModelLoad() throws EolModelLoadingException {
+		String dataUrl = new String("file:." + OWL_DEMO_DATAMODEL);
+		String schemaUrl = new String("file:." + OWL_DEMO_SCHEMAMODEL);
+		StringProperties props = createPropertyString(dataUrl, schemaUrl, LANGUAGE_PREFERENCE_EN_STRING);
+
+		this.context = new EolContext();
+		copyModelFiles();
+		model.load(props);
+		loadedModelTest();
+	}
+
+	@Test
+	public void longFileUrlModelLoad() throws EolModelLoadingException {
+		String dataUrl = new String(getTestProjectURIString() + OWL_DEMO_DATAMODEL);
+		String schemaUrl = new String(getTestProjectURIString() + OWL_DEMO_SCHEMAMODEL);
+		StringProperties props = createPropertyString(dataUrl, schemaUrl, LANGUAGE_PREFERENCE_EN_STRING);
+
+		this.context = new EolContext();
+		copyModelFiles();
+		model.load(props);
+		loadedModelTest();
+
+	}
+
+	@Test
+	public void platformUrlModelLoad() throws EolModelLoadingException {
+		String dataUrl = new String("platform:/resource/" + PROJECT_URL + "/" + OWL_DEMO_DATAMODEL);
+		String schemaUrl = new String("platform:/resource/" + PROJECT_URL + "/" + OWL_DEMO_SCHEMAMODEL);
+		StringProperties props = createPropertyString(dataUrl, schemaUrl, LANGUAGE_PREFERENCE_EN_STRING);
+
+		this.context = new EolContext();
+		copyModelFiles();
+
+		model.load(props);
+		loadedModelTest();
+	}
+
+	@Test(expected = EolModelLoadingException.class)
+	public void missingResourceInPlatformUrlModelLoad() throws EolModelLoadingException {
+		String dataUrl = new String("platform:/-/" + PROJECT_URL + "/" + OWL_DEMO_DATAMODEL);
+		String schemaUrl = new String("platform:/-/" + PROJECT_URL + "/" + OWL_DEMO_SCHEMAMODEL);
+		StringProperties props = createPropertyString(dataUrl, schemaUrl, LANGUAGE_PREFERENCE_EN_STRING);
+
+		this.context = new EolContext();
+		copyModelFiles();
+		model.load(props);
+	}
+
+	@Test(expected = EolModelLoadingException.class)
+	public void missingProjectUrlInPlatformUrlModelLoad() throws EolModelLoadingException {
+		String dataUrl = new String("platform:/resource" + OWL_DEMO_DATAMODEL);
+		String schemaUrl = new String("platform:/resource" + OWL_DEMO_SCHEMAMODEL);
+		StringProperties props = createPropertyString(dataUrl, schemaUrl, LANGUAGE_PREFERENCE_EN_STRING);
+
+		this.context = new EolContext();
+		copyModelFiles();
+		model.load(props);
+	}
+
+	@After
+	public void teardown() {
+		if (model != null) {
+			model.dispose();
+		}
+	}
+	
+	private void loadedModelTest() {		
+		assertTrue(model != null);
+		RDFResource element = model.getElementById(URI_WHITEBOX);
+		Object motherBoard = element.getProperty("eg:motherBoard", context);
+		assertTrue("motherBoard has max cardinality of 1 should only have that value returned ",
+			motherBoard instanceof RDFResource);
+	}
+
+	private void copyModelFiles() {
+		try {
+			super.copyIntoProject(OWL_DEMO_DATAMODEL);
+			super.copyIntoProject(OWL_DEMO_SCHEMAMODEL);
+		} catch (Exception e) {
+			// e.printStackTrace();
+		}
+	}
+
+	protected StringProperties createPropertyString(String dataModelUri, String schemaModelUri,
+			String languagePreference) {
+		this.model = new EclipseRDFModel();
+		StringProperties props = new StringProperties();
+		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
+		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
+		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
+		System.out.println("props: " + props.toString());
+		return props;
+	}
+}


### PR DESCRIPTION
1. Added support for the use of Platform URLs when configuring a Model.
2. Updated the Model Edit Dialogue, adding from Workspace creates a `platform:` URL.
3. Tests were added to cover URL processing and model loading under an Eclipse Project space.

For `platform:` URL support an EclipseRDFModel class should be used instead of RDFModel. The EclipseRDFModel has some additional processing added for converting incompatible `platform:` URLs to `file:` (both data and schema lists checked and converted). Processing of the Model URL lists (data & schema) is done using existing Java and Eclipse facilities, notably, Eclipse's runtime FileLocator, is used to resolve the location of a Model file on the system's file system. 

With the `platform:` protocol support, changes to the Model Edit dialogue have been made. Adding model files from the Workspace (button)  now adds a `platform:` URL instead of a `file:`. This should help improve the portability of launch configurations between systems.

To test the processing of the URLs an additional set of Junit tests have been added. This also required the addition of a small class that can create an Eclipse Project workspace for tests to be run. _When testing under an Eclipse Project space any model files being accessed by Jena in the tests must be copied into the project workspace **and the file system must be synchronised with the project**, before the test is executed._

- Tests for the `platform:` URLs check the conversion of a good URL by loading and model then querying with Jena. 
- A set of checks for failures to load a model because of a badly formed `platform:` URL is performed, and the errors report "no file path" which vaguely refers to the URL conversion process not finding the files at the given URL (i.e. platform URL doesn't point to a file). 
- Expected to work `file:` '.' '/' URLs are tested to confirm they work, again a model is loaded and queried.