### PR TITLE
20 add option to trigger owl validation on load

### DIFF
--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
@@ -50,8 +50,6 @@ import org.eclipse.swt.widgets.Text;
 public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialog {
 	private static final String[] RDFFILE_EXTENSIONS = new String[] { "*.rdf", "*.ttl", "*.nt", "*.nq", "*.trig", "*.owl", "*.jsonld", "*.trdf", "*.rt", "*.rpb", "*.pbrdf", "*.rj", "*.trix", "*.*"};
 	
-	protected static final boolean DEFAULT_VALIDATION_SELECTION = true;
-	
 	private static final String SAMPLE_URL = "http://changeme";
 
 	protected class PrefixEditingSupport extends EditingSupport {
@@ -517,15 +515,20 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 	}
 	
 	
-	
+	protected String validateModel;
 	protected Button validateModelCheckBox;
 	private Composite createValidateModelGroup(Composite parent) {
 		final Composite groupContent = DialogUtil.createGroupContainer(parent, "Model validation", 1);
 
 		validateModelCheckBox = new Button(groupContent, SWT.CHECK);
 		validateModelCheckBox.setText("Run Jena's model validation on loaded models");
-		validateModelCheckBox.setSelection(DEFAULT_VALIDATION_SELECTION);
-
+		
+		if (validateModel.contains(RDFModel.VALIDATION_SELECTION_DEFAULT)) {
+			validateModelCheckBox.setSelection(true);
+		} else {
+			validateModelCheckBox.setSelection(false);
+		}
+		
 		groupContent.layout();
 		groupContent.pack();
 		return groupContent;
@@ -565,7 +568,10 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		
 		languagePreferenceText.setText(properties.getProperty(RDFModel.PROPERTY_LANGUAGE_PREFERENCE));
 		
-		validateModelCheckBox.setSelection(properties.getBooleanProperty(RDFModel.PROPERTY_VALIDATE_MODEL, DEFAULT_VALIDATION_SELECTION));		
+		validateModel = properties.getProperty(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_DEFAULT); // Load any saved property and default to Jena if none
+		if (validateModel == RDFModel.VALIDATION_SELECTION_NONE) {
+			validateModelCheckBox.setSelection(false);
+		}
 		
 		this.dataModelUrlListViewer.refresh();
 		this.schemaModelUrlListViewer.refresh();
@@ -595,7 +601,11 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		properties.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE,
 				languagePreferenceText.getText().replaceAll("\\s", ""));
 		
-		properties.put(RDFModel.PROPERTY_VALIDATE_MODEL, validateModelCheckBox.getSelection());
+		if(validateModelCheckBox.getSelection()) {
+			properties.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_DEFAULT);	
+		} else {
+			properties.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);
+		}
 	}
 
 	protected void validateForm() {

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
@@ -49,7 +49,9 @@ import org.eclipse.swt.widgets.Text;
 
 public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialog {
 	private static final String[] RDFFILE_EXTENSIONS = new String[] { "*.rdf", "*.ttl", "*.nt", "*.nq", "*.trig", "*.owl", "*.jsonld", "*.trdf", "*.rt", "*.rpb", "*.pbrdf", "*.rj", "*.trix", "*.*"};
-
+	
+	protected static final boolean DEFAULT_VALIDATION_SELECTION = true;
+	
 	private static final String SAMPLE_URL = "http://changeme";
 
 	protected class PrefixEditingSupport extends EditingSupport {
@@ -195,7 +197,7 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		createSchemaModelRDFUrlsGroup(control);
 		createNamespaceMappingGroup(control);  // Custom prefixes
 		createLanguagePreferenceGroup(control);
-		createJenaValidateModelGroup(control);
+		createValidateModelGroup(control);
 	}
 
 	private Composite createNamespaceMappingGroup(Composite parent) {
@@ -494,7 +496,6 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 	
 	protected Label languagePreferenceLabel;
 	protected Text languagePreferenceText;
-
 	private Composite createLanguagePreferenceGroup(Composite parent) {
 		final Composite groupContent = DialogUtil.createGroupContainer(parent, "Language tag preference", 1);
 		
@@ -516,15 +517,14 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 	}
 	
 	
-	protected final boolean DEFAULT_VALIDATION_SELECTION = true;
-	protected Button jenaValidateModelCheckBox;
-
-	private Composite createJenaValidateModelGroup(Composite parent) {
+	
+	protected Button validateModelCheckBox;
+	private Composite createValidateModelGroup(Composite parent) {
 		final Composite groupContent = DialogUtil.createGroupContainer(parent, "Model validation", 1);
 
-		jenaValidateModelCheckBox = new Button(groupContent, SWT.CHECK);
-		jenaValidateModelCheckBox.setText("Run Jena's model validation on loaded models");
-		jenaValidateModelCheckBox.setSelection(DEFAULT_VALIDATION_SELECTION);
+		validateModelCheckBox = new Button(groupContent, SWT.CHECK);
+		validateModelCheckBox.setText("Run Jena's model validation on loaded models");
+		validateModelCheckBox.setSelection(DEFAULT_VALIDATION_SELECTION);
 
 		groupContent.layout();
 		groupContent.pack();
@@ -565,7 +565,7 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		
 		languagePreferenceText.setText(properties.getProperty(RDFModel.PROPERTY_LANGUAGE_PREFERENCE));
 		
-		jenaValidateModelCheckBox.setSelection(properties.getBooleanProperty(RDFModel.PROPERTY_JENA_VALIDATE_MODEL, DEFAULT_VALIDATION_SELECTION));		
+		validateModelCheckBox.setSelection(properties.getBooleanProperty(RDFModel.PROPERTY_VALIDATE_MODEL, DEFAULT_VALIDATION_SELECTION));		
 		
 		this.dataModelUrlListViewer.refresh();
 		this.schemaModelUrlListViewer.refresh();
@@ -595,7 +595,7 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		properties.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE,
 				languagePreferenceText.getText().replaceAll("\\s", ""));
 		
-		properties.put(RDFModel.PROPERTY_JENA_VALIDATE_MODEL, jenaValidateModelCheckBox.getSelection());
+		properties.put(RDFModel.PROPERTY_VALIDATE_MODEL, validateModelCheckBox.getSelection());
 	}
 
 	protected void validateForm() {

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
@@ -185,13 +185,17 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		return "RDF";
 	}
 
+	//
+	// Ordering of Groups in Dialogue window
+	
 	@Override
 	protected void createGroups(Composite control) {
 		createNameAliasGroup(control);
 		createDataModelRDFUrlsGroup(control);
 		createSchemaModelRDFUrlsGroup(control);
-		createNamespaceMappingGroup(control);
+		createNamespaceMappingGroup(control);  // Custom prefixes
 		createLanguagePreferenceGroup(control);
+		createJenaValidateModelGroup(control);
 	}
 
 	private Composite createNamespaceMappingGroup(Composite parent) {
@@ -511,7 +515,23 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		return groupContent;
 	}
 	
-	@Override
+	
+	protected final boolean DEFAULT_VALIDATION_SELECTION = true;
+	protected Button jenaValidateModelCheckBox;
+
+	private Composite createJenaValidateModelGroup(Composite parent) {
+		final Composite groupContent = DialogUtil.createGroupContainer(parent, "Model validation", 1);
+
+		jenaValidateModelCheckBox = new Button(groupContent, SWT.CHECK);
+		jenaValidateModelCheckBox.setText("Run Jena's model validation on loaded models");
+		jenaValidateModelCheckBox.setSelection(DEFAULT_VALIDATION_SELECTION);
+
+		groupContent.layout();
+		groupContent.pack();
+		return groupContent;
+	}
+	
+	@Override	
 	protected void loadProperties(){
 		super.loadProperties();
 		if (properties == null) return;
@@ -544,7 +564,9 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		}
 		
 		languagePreferenceText.setText(properties.getProperty(RDFModel.PROPERTY_LANGUAGE_PREFERENCE));
-
+		
+		jenaValidateModelCheckBox.setSelection(properties.getBooleanProperty(RDFModel.PROPERTY_JENA_VALIDATE_MODEL, DEFAULT_VALIDATION_SELECTION));		
+		
 		this.dataModelUrlListViewer.refresh();
 		this.schemaModelUrlListViewer.refresh();
 		this.nsMappingTable.refresh();
@@ -572,6 +594,8 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		
 		properties.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE,
 				languagePreferenceText.getText().replaceAll("\\s", ""));
+		
+		properties.put(RDFModel.PROPERTY_JENA_VALIDATE_MODEL, jenaValidateModelCheckBox.getSelection());
 	}
 
 	protected void validateForm() {

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
@@ -49,7 +49,7 @@ import org.eclipse.swt.widgets.Text;
 
 public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialog {
 	private static final String[] RDFFILE_EXTENSIONS = new String[] { "*.rdf", "*.ttl", "*.nt", "*.nq", "*.trig", "*.owl", "*.jsonld", "*.trdf", "*.rt", "*.rpb", "*.pbrdf", "*.rj", "*.trix", "*.*"};
-	
+
 	private static final String SAMPLE_URL = "http://changeme";
 
 	protected class PrefixEditingSupport extends EditingSupport {

--- a/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf.dt/src/org/eclipse/epsilon/emc/rdf/dt/RDFModelConfigurationDialog.java
@@ -193,7 +193,7 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		createNameAliasGroup(control);
 		createDataModelRDFUrlsGroup(control);
 		createSchemaModelRDFUrlsGroup(control);
-		createNamespaceMappingGroup(control);  // Custom prefixes
+		createNamespaceMappingGroup(control);
 		createLanguagePreferenceGroup(control);
 		createValidateModelGroup(control);
 	}
@@ -516,19 +516,16 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 	
 	
 	protected String validateModel;
+
 	protected Button validateModelCheckBox;
 	private Composite createValidateModelGroup(Composite parent) {
 		final Composite groupContent = DialogUtil.createGroupContainer(parent, "Model validation", 1);
 
 		validateModelCheckBox = new Button(groupContent, SWT.CHECK);
 		validateModelCheckBox.setText("Run Jena's model validation on loaded models");
-		
-		if (validateModel.contains(RDFModel.VALIDATION_SELECTION_DEFAULT)) {
-			validateModelCheckBox.setSelection(true);
-		} else {
-			validateModelCheckBox.setSelection(false);
-		}
-		
+		boolean isJenaValidationEnabled = RDFModel.VALIDATION_SELECTION_JENA.equals(validateModel);
+		validateModelCheckBox.setSelection(isJenaValidationEnabled);
+
 		groupContent.layout();
 		groupContent.pack();
 		return groupContent;
@@ -568,10 +565,9 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		
 		languagePreferenceText.setText(properties.getProperty(RDFModel.PROPERTY_LANGUAGE_PREFERENCE));
 		
-		validateModel = properties.getProperty(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_DEFAULT); // Load any saved property and default to Jena if none
-		if (validateModel == RDFModel.VALIDATION_SELECTION_NONE) {
-			validateModelCheckBox.setSelection(false);
-		}
+		// Load any saved property and default to Jena if none
+		validateModel = properties.getProperty(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_JENA);
+		validateModelCheckBox.setSelection(RDFModel.VALIDATION_SELECTION_JENA.equals(validateModel));
 		
 		this.dataModelUrlListViewer.refresh();
 		this.schemaModelUrlListViewer.refresh();
@@ -601,8 +597,8 @@ public class RDFModelConfigurationDialog extends AbstractModelConfigurationDialo
 		properties.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE,
 				languagePreferenceText.getText().replaceAll("\\s", ""));
 		
-		if(validateModelCheckBox.getSelection()) {
-			properties.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_DEFAULT);	
+		if (validateModelCheckBox.getSelection()) {
+			properties.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_JENA);
 		} else {
 			properties.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);
 		}

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -215,6 +215,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		loadProperty(properties, PROPERTY_SCHEMA_URIS, this.schemaURIs);
 		loadPropertyPrefixes(properties);
 		loadPropertyLanguagePreference(properties);
+		loadPropertyJaneValidateModel(properties);
 
 		load();
 	}
@@ -458,12 +459,14 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	
 	//
 	// PROPERTY JANA VALIDATE MODEL 
-	
+	protected final boolean DEFAULT_VALIDATION_SELECTION = true;
 	public static final String PROPERTY_JENA_VALIDATE_MODEL = "jenaValidateModel";
-	protected final boolean jenaValidateModel = true;
+	protected boolean jenaValidateModel = DEFAULT_VALIDATION_SELECTION;
 	
 	private void loadPropertyJaneValidateModel(StringProperties properties) {
 		// TODO load the boolean from the Property string PROPERTY_JENA_VALIDATE_MODEL
+		jenaValidateModel = properties.getBooleanProperty(RDFModel.PROPERTY_JENA_VALIDATE_MODEL, DEFAULT_VALIDATION_SELECTION);
+		System.out.println(this + "Loaded jenaValidateModel: " + jenaValidateModel);
 	}
 	
 	public boolean isJenaValidateModel () {

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -230,7 +230,11 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		
 		// After Loading all scheme, data models and inferring the full model, validate
 		if (validateModel) {
-			validateModel();
+			try {
+				validateModel();
+			} catch (Exception e) {
+				throw new EolModelLoadingException(e, this);
+			}
 		}
 	}
 
@@ -297,27 +301,25 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	
 	//
 	// VALIDATE MODEL
-	
-	ValidityReport modelValidityReport = null;
 
-	private void validateModel() {
-		// TODO Validate the ontModel
+	private void validateModel() throws Exception {
+		/*
+		 * The way the model is validated by Jena depends on how the new OntModel was
+		 * created by the ModelFactory.
+		 */
 
-		modelValidityReport = model.validate();
-
-		if (!modelValidityReport.isClean()) {
-			// Throw error
-			System.err.println("ontModel Validation Clean: " + modelValidityReport.isClean());
-		}
-
-		if (!modelValidityReport.isValid()) {
-			// Throw error
-
-			System.err.println("ontModel Validation Valid: " + modelValidityReport.isValid());
+		ValidityReport modelValidityReport = model.validate();
+		
+		if (!modelValidityReport.isValid() | (!modelValidityReport.isClean())) {
+			// Throw error with a string containing the validity report 
+			String reportString = "The loaded model is not valid or not clean\n";
+			int i = 1;
 			for (Iterator o = modelValidityReport.getReports(); o.hasNext();) {
 				ValidityReport.Report report = (ValidityReport.Report) o.next();
-				System.out.println(" - " + report);
+				reportString = reportString.concat(" " + i + ", " + report.toString());
+				i++;
 			}
+			throw new Exception(reportString.toString());
 		}
 	}
 		

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -49,7 +49,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	public static final String PROPERTY_SCHEMA_URIS = "schemaUris";
 	public static final String PROPERTY_LANGUAGE_PREFERENCE = "languagePreference";
 	public static final String PROPERTY_PREFIXES = "prefixes";
-	public static final String PROPERTY_VALIDATE_MODEL = "jenaValidateModel";
+	public static final String PROPERTY_VALIDATE_MODEL = "enableModelValidation";
 	public static final boolean DEFAULT_VALIDATION_SELECTION = true;
 	
 	// Model loading and properties are located at the bottom of this Class

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -50,8 +50,10 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	public static final String PROPERTY_LANGUAGE_PREFERENCE = "languagePreference";
 	public static final String PROPERTY_PREFIXES = "prefixes";
 	public static final String PROPERTY_VALIDATE_MODEL = "enableModelValidation";
-	public static final String VALIDATION_SELECTION_DEFAULT = "jena";
+
+	public static final String VALIDATION_SELECTION_JENA = "jena";
 	public static final String VALIDATION_SELECTION_NONE = "none";
+	public static final String VALIDATION_SELECTION_DEFAULT = VALIDATION_SELECTION_JENA;
 	
 	// Model loading and properties are located at the bottom of this Class
 	
@@ -230,7 +232,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		load();
 		
 		// After Loading all scheme, data models and inferring the full model, validate
-		if (validationProperty.contains(VALIDATION_SELECTION_DEFAULT)) {
+		if (validationProperty.contains(VALIDATION_SELECTION_JENA)) {
 			try {
 				validateModel();
 			} catch (Exception e) {
@@ -500,12 +502,10 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	//
 	// PROPERTY JANA VALIDATE MODEL 
 	
-
-
 	protected String validationProperty = VALIDATION_SELECTION_DEFAULT;
 	
 	private void loadPropertyValidateModel(StringProperties properties) {
-		validationProperty = properties.getProperty(RDFModel.PROPERTY_VALIDATE_MODEL, VALIDATION_SELECTION_DEFAULT);
+		validationProperty = properties.getProperty(RDFModel.PROPERTY_VALIDATE_MODEL, VALIDATION_SELECTION_JENA);
 	}
 	
 	public String getValidationProperty () {

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -50,7 +50,8 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	public static final String PROPERTY_LANGUAGE_PREFERENCE = "languagePreference";
 	public static final String PROPERTY_PREFIXES = "prefixes";
 	public static final String PROPERTY_VALIDATE_MODEL = "enableModelValidation";
-	public static final boolean DEFAULT_VALIDATION_SELECTION = true;
+	public static final String VALIDATION_SELECTION_DEFAULT = "jena";
+	public static final String VALIDATION_SELECTION_NONE = "none";
 	
 	// Model loading and properties are located at the bottom of this Class
 	
@@ -229,7 +230,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		load();
 		
 		// After Loading all scheme, data models and inferring the full model, validate
-		if (validateModel) {
+		if (validationProperty.contains(VALIDATION_SELECTION_DEFAULT)) {
 			try {
 				validateModel();
 			} catch (Exception e) {
@@ -501,15 +502,14 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	
 
 
-	protected boolean validateModel = DEFAULT_VALIDATION_SELECTION;
+	protected String validationProperty = VALIDATION_SELECTION_DEFAULT;
 	
 	private void loadPropertyValidateModel(StringProperties properties) {
-		// TODO load the boolean from the Property string PROPERTY_JENA_VALIDATE_MODEL
-		validateModel = properties.getBooleanProperty(RDFModel.PROPERTY_VALIDATE_MODEL, DEFAULT_VALIDATION_SELECTION);
+		validationProperty = properties.getProperty(RDFModel.PROPERTY_VALIDATE_MODEL, VALIDATION_SELECTION_DEFAULT);
 	}
 	
-	public boolean hasJenaValidatedModel () {
-		return validateModel;
+	public String getValidationProperty () {
+		return validationProperty;
 	}
 	
 	//

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -44,6 +44,13 @@ import org.eclipse.epsilon.eol.models.CachedModel;
 import org.eclipse.epsilon.eol.models.IRelativePathResolver;
 
 public class RDFModel extends CachedModel<RDFModelElement> {
+
+	public static final String PROPERTY_DATA_URIS = "uris";
+	public static final String PROPERTY_SCHEMA_URIS = "schemaUris";
+	public static final String PROPERTY_LANGUAGE_PREFERENCE = "languagePreference";
+	public static final String PROPERTY_PREFIXES = "prefixes";
+	public static final String PROPERTY_VALIDATE_MODEL = "jenaValidateModel";
+	public static final boolean DEFAULT_VALIDATION_SELECTION = true;
 	
 	// Model loading and properties are located at the bottom of this Class
 	
@@ -310,10 +317,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 				
 		}
 	}
-	
-	
-	
-	
+		
 	@Override
 	protected void disposeModel() {
 		model = null;
@@ -351,7 +355,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	//
 	// PROPERTY DATA URIS
 	
-	public static final String PROPERTY_DATA_URIS = "uris";
 	protected final List<String> dataURIs = new ArrayList<>();
 	
 	public List<String> getDataUris() {
@@ -366,7 +369,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	//
 	// PROPERTY SCHEMA URIS
 	
-	public static final String PROPERTY_SCHEMA_URIS = "schemaUris";
 	protected final List<String> schemaURIs = new ArrayList<>();
 	
 	public List<String> getSchemaUris() {
@@ -391,7 +393,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	 * should be added to the prefix->URI map of the loaded RDF resource. These
 	 * pairs will take precedence over existing pairs in the resource.
 	 */
-	public static final String PROPERTY_PREFIXES = "prefixes";
 	protected final Map<String, String> customPrefixesMap = new HashMap<>();
 	
 	private void loadPropertyPrefixes (StringProperties properties) {
@@ -458,7 +459,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	//
 	// PROPERTY LANGUAGE PREFERENCE
 	
-	public static final String PROPERTY_LANGUAGE_PREFERENCE = "languagePreference";
+
 	protected final List<String> languagePreference = new ArrayList<>();
 
 	private void loadPropertyLanguagePreference(StringProperties properties) throws EolModelLoadingException {
@@ -493,8 +494,8 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	//
 	// PROPERTY JANA VALIDATE MODEL 
 	
-	protected final boolean DEFAULT_VALIDATION_SELECTION = true;
-	public static final String PROPERTY_VALIDATE_MODEL = "jenaValidateModel";
+
+
 	protected boolean validateModel = DEFAULT_VALIDATION_SELECTION;
 	
 	private void loadPropertyValidateModel(StringProperties properties) {

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -211,10 +211,10 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		 * configuration of this RDFModel. This is the same as in other popular
 		 * EMC drivers (e.g. the EmfModel class).
 		 */
-		loadCommaSeparatedProperty(properties, PROPERTY_DATA_URIS, this.dataURIs);
-		loadCommaSeparatedProperty(properties, PROPERTY_SCHEMA_URIS, this.schemaURIs);
-		loadCommaSeperatedPropertyPrefixes(properties);
-		loadCommaSeperatedLanguagePreference(properties);
+		loadProperty(properties, PROPERTY_DATA_URIS, this.dataURIs);
+		loadProperty(properties, PROPERTY_SCHEMA_URIS, this.schemaURIs);
+		loadPropertyPrefixes(properties);
+		loadPropertyLanguagePreference(properties);
 
 		load();
 	}
@@ -268,7 +268,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		}
 	}
 
-	private void loadCommaSeparatedProperty(StringProperties properties, String propertyName, List<String> targetList) {
+	private void loadProperty(StringProperties properties, String propertyName, List<String> targetList) {
 		targetList.clear();
 		{
 			String sUris = properties.getProperty(propertyName, "").strip();
@@ -360,7 +360,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	public static final String PROPERTY_PREFIXES = "prefixes";
 	protected final Map<String, String> customPrefixesMap = new HashMap<>();
 	
-	private void loadCommaSeperatedPropertyPrefixes (StringProperties properties) {
+	private void loadPropertyPrefixes (StringProperties properties) {
 		this.customPrefixesMap.clear();
 		String sPrefixes = properties.getProperty(PROPERTY_PREFIXES, "").strip();
 		if (!sPrefixes.isEmpty()) {
@@ -427,7 +427,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	public static final String PROPERTY_LANGUAGE_PREFERENCE = "languagePreference";
 	protected final List<String> languagePreference = new ArrayList<>();
 
-	private void loadCommaSeperatedLanguagePreference(StringProperties properties) throws EolModelLoadingException {
+	private void loadPropertyLanguagePreference(StringProperties properties) throws EolModelLoadingException {
 		this.languagePreference.clear();
 		String sLanguagePreference = properties.getProperty(PROPERTY_LANGUAGE_PREFERENCE, "").strip();
 		if (!sLanguagePreference.isEmpty()) {
@@ -454,6 +454,20 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	public static boolean isValidLanguageTag (String bcp47tag) {
 		boolean isValidBCP47 = !("und".equals(Locale.forLanguageTag(bcp47tag).toLanguageTag()));
 		return isValidBCP47;
+	}
+	
+	//
+	// PROPERTY JANA VALIDATE MODEL 
+	
+	public static final String PROPERTY_JENA_VALIDATE_MODEL = "jenaValidateModel";
+	protected final boolean jenaValidateModel = true;
+	
+	private void loadPropertyJaneValidateModel(StringProperties properties) {
+		// TODO load the boolean from the Property string PROPERTY_JENA_VALIDATE_MODEL
+	}
+	
+	public boolean isJenaValidateModel () {
+		return jenaValidateModel;
 	}
 	
 	//

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.jena.ontology.OntModel;
+import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.InfModel;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -31,6 +32,7 @@ import org.apache.jena.rdf.model.ResIterator;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.reasoner.Reasoner;
 import org.apache.jena.reasoner.ReasonerRegistry;
+import org.apache.jena.reasoner.ValidityReport;
 import org.apache.jena.vocabulary.RDF;
 import org.eclipse.epsilon.common.util.StringProperties;
 import org.eclipse.epsilon.eol.exceptions.EolRuntimeException;
@@ -215,9 +217,10 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		loadProperty(properties, PROPERTY_SCHEMA_URIS, this.schemaURIs);
 		loadPropertyPrefixes(properties);
 		loadPropertyLanguagePreference(properties);
-		loadPropertyJaneValidateModel(properties);
+		loadPropertyValidateModel(properties);
 
 		load();
+		validateModel();
 	}
 	
 	@Override
@@ -248,7 +251,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 			}
 
 			//Create an OntModel to handle the data model being loaded or inferred from data and schema
-			this.model = ModelFactory.createOntologyModel();
+			this.model = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM_RULE_INF);
 			
 			if (reasonerType == ReasonerType.NONE) {
 				// Only the OntModel bits are added to the dataModel being loaded.
@@ -280,6 +283,36 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 			}
 		}
 	}
+	
+	//
+	// VALIDATE MODEL
+	
+	ValidityReport modelValidityReport = null;
+	private void validateModel() {	
+		// TODO Validate the ontModel
+		
+		if (validateModel) {
+			modelValidityReport = model.validate();
+			
+			if (!modelValidityReport.isClean()) {
+				// Throw error
+				System.err.println("oModel jena Validation Clean: " + modelValidityReport.isClean());
+			}
+						
+			if(!modelValidityReport.isValid()) {
+				// Throw error
+				System.err.println("oModel jena Validation Valid: " + modelValidityReport.isValid());	
+			    for (Iterator o = modelValidityReport.getReports(); o.hasNext(); ) {
+			        ValidityReport.Report report = (ValidityReport.Report)o.next();
+			        System.out.println(" - " + report);
+			    }
+			}
+				
+		}
+	}
+	
+	
+	
 	
 	@Override
 	protected void disposeModel() {
@@ -459,18 +492,18 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	
 	//
 	// PROPERTY JANA VALIDATE MODEL 
-	protected final boolean DEFAULT_VALIDATION_SELECTION = true;
-	public static final String PROPERTY_JENA_VALIDATE_MODEL = "jenaValidateModel";
-	protected boolean jenaValidateModel = DEFAULT_VALIDATION_SELECTION;
 	
-	private void loadPropertyJaneValidateModel(StringProperties properties) {
+	protected final boolean DEFAULT_VALIDATION_SELECTION = true;
+	public static final String PROPERTY_VALIDATE_MODEL = "jenaValidateModel";
+	protected boolean validateModel = DEFAULT_VALIDATION_SELECTION;
+	
+	private void loadPropertyValidateModel(StringProperties properties) {
 		// TODO load the boolean from the Property string PROPERTY_JENA_VALIDATE_MODEL
-		jenaValidateModel = properties.getBooleanProperty(RDFModel.PROPERTY_JENA_VALIDATE_MODEL, DEFAULT_VALIDATION_SELECTION);
-		System.out.println(this + "Loaded jenaValidateModel: " + jenaValidateModel);
+		validateModel = properties.getBooleanProperty(RDFModel.PROPERTY_VALIDATE_MODEL, DEFAULT_VALIDATION_SELECTION);
 	}
 	
-	public boolean isJenaValidateModel () {
-		return jenaValidateModel;
+	public boolean hasJenaValidatedModel () {
+		return validateModel;
 	}
 	
 	//

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -382,7 +382,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		}
 	}
 
-	public String getValidationMode () {
+	public String getValidationMode() {
 		return validationMode;
 	}
 

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -227,7 +227,23 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		loadPropertyValidateModel(properties);
 
 		load();
-		validateModel();
+		
+		// After Loading all scheme, data models and inferring the full model, validate
+		if (validateModel) {
+			validateModel();
+		}
+	}
+
+	private void loadProperty(StringProperties properties, String propertyName, List<String> targetList) {
+		targetList.clear();
+		{
+			String sUris = properties.getProperty(propertyName, "").strip();
+			if (!sUris.isEmpty()) {
+				for (String uri : sUris.split(",")) {
+					targetList.add(uri.strip());
+				}
+			}
+		}
 	}
 	
 	@Override
@@ -278,43 +294,30 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 			throw new EolModelLoadingException(ex, this);
 		}
 	}
-
-	private void loadProperty(StringProperties properties, String propertyName, List<String> targetList) {
-		targetList.clear();
-		{
-			String sUris = properties.getProperty(propertyName, "").strip();
-			if (!sUris.isEmpty()) {
-				for (String uri : sUris.split(",")) {
-					targetList.add(uri.strip());
-				}
-			}
-		}
-	}
 	
 	//
 	// VALIDATE MODEL
 	
 	ValidityReport modelValidityReport = null;
-	private void validateModel() {	
+
+	private void validateModel() {
 		// TODO Validate the ontModel
-		
-		if (validateModel) {
-			modelValidityReport = model.validate();
-			
-			if (!modelValidityReport.isClean()) {
-				// Throw error
-				System.err.println("oModel jena Validation Clean: " + modelValidityReport.isClean());
+
+		modelValidityReport = model.validate();
+
+		if (!modelValidityReport.isClean()) {
+			// Throw error
+			System.err.println("ontModel Validation Clean: " + modelValidityReport.isClean());
+		}
+
+		if (!modelValidityReport.isValid()) {
+			// Throw error
+
+			System.err.println("ontModel Validation Valid: " + modelValidityReport.isValid());
+			for (Iterator o = modelValidityReport.getReports(); o.hasNext();) {
+				ValidityReport.Report report = (ValidityReport.Report) o.next();
+				System.out.println(" - " + report);
 			}
-						
-			if(!modelValidityReport.isValid()) {
-				// Throw error
-				System.err.println("oModel jena Validation Valid: " + modelValidityReport.isValid());	
-			    for (Iterator o = modelValidityReport.getReports(); o.hasNext(); ) {
-			        ValidityReport.Report report = (ValidityReport.Report)o.next();
-			        System.out.println(" - " + report);
-			    }
-			}
-				
 		}
 	}
 		

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.jena.ontology.OntModel;
-import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.InfModel;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -33,6 +32,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.reasoner.Reasoner;
 import org.apache.jena.reasoner.ReasonerRegistry;
 import org.apache.jena.reasoner.ValidityReport;
+import org.apache.jena.reasoner.ValidityReport.Report;
 import org.apache.jena.vocabulary.RDF;
 import org.eclipse.epsilon.common.util.StringProperties;
 import org.eclipse.epsilon.eol.exceptions.EolRuntimeException;
@@ -45,18 +45,47 @@ import org.eclipse.epsilon.eol.models.IRelativePathResolver;
 
 public class RDFModel extends CachedModel<RDFModelElement> {
 
-	public static final String PROPERTY_DATA_URIS = "uris";
-	public static final String PROPERTY_SCHEMA_URIS = "schemaUris";
 	public static final String PROPERTY_LANGUAGE_PREFERENCE = "languagePreference";
+
+	public static final String PROPERTY_SCHEMA_URIS = "schemaUris";
+	public static final String PROPERTY_DATA_URIS = "uris";
+
+	/**
+	 * One of the keys used to construct the first argument to
+	 * {@link #load(StringProperties, String)}.
+	 *
+	 * This key should be set to a comma-separated list of prefix=uri pairs that
+	 * should be added to the prefix->URI map of the loaded RDF resource. These
+	 * pairs will take precedence over existing pairs in the resource.
+	 */
 	public static final String PROPERTY_PREFIXES = "prefixes";
 	public static final String PROPERTY_VALIDATE_MODEL = "enableModelValidation";
 
 	public static final String VALIDATION_SELECTION_JENA = "jena";
 	public static final String VALIDATION_SELECTION_NONE = "none";
 	public static final String VALIDATION_SELECTION_DEFAULT = VALIDATION_SELECTION_JENA;
-	
-	// Model loading and properties are located at the bottom of this Class
-	
+
+	protected final List<String> languagePreference = new ArrayList<>();
+	protected final Map<String, String> customPrefixesMap = new HashMap<>();
+
+	// TODO add to this list to cover reasoner types in the ReasonerRegistry Class
+	public enum ReasonerType {
+		NONE,
+		OWL_FULL;
+	}
+
+	protected ReasonerType reasonerType = ReasonerType.NONE;
+
+	public ReasonerType getReasonerType() {
+		return reasonerType;
+	}
+
+	public void setReasonerType(ReasonerType rdfsReasonerType) {
+		this.reasonerType = rdfsReasonerType;
+	}
+
+	protected final List<String> schemaURIs = new ArrayList<>();
+	protected final List<String> dataURIs = new ArrayList<>();
 	protected OntModel model;
 
 	public RDFModel() {
@@ -65,6 +94,11 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	
 	protected RDFResource createResource(Resource aResource) {
 		return new RDFResource(aResource, this);
+	}
+
+	@Override
+	public Object getEnumerationValue(String enumeration, String label) throws EolEnumerationValueNotFoundException {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override
@@ -80,21 +114,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 
 		// TODO Generic names in case there isn't an RDF.type relationship?
 		return null;
-	}
-	
-	@Override
-	public boolean hasType(String type) {
-		try {
-			getTypeResourceByName(type);
-			return true;
-		} catch (EolModelElementTypeNotFoundException e) {
-			return false;
-		}
-	}
-
-	@Override
-	protected Object getCacheKeyForType(String type) throws EolModelElementTypeNotFoundException {
-		return getTypeResourceByName(type);
 	}
 
 	private String getQualifiedTypeName(RDFResource typeResource) {
@@ -121,6 +140,11 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	}
 
 	@Override
+	public void setElementId(Object instance, String newId) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public boolean owns(Object instance) {
 		return instance instanceof RDFModelElement && ((RDFModelElement) instance).getModel() == this;
 	}
@@ -129,7 +153,121 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	public boolean isInstantiable(String type) {
 		return false;
 	}
-	
+
+	@Override
+	public boolean hasType(String type) {
+		try {
+			getTypeResourceByName(type);
+			return true;
+		} catch (EolModelElementTypeNotFoundException e) {
+			return false;
+		}
+	}
+
+	@Override
+	public void load(StringProperties properties, IRelativePathResolver resolver) throws EolModelLoadingException {
+		super.load(properties, resolver);
+
+		/*
+		 * This method assumes that the StringProperties replaces all previous
+		 * configuration of this RDFModel. This is the same as in other popular
+		 * EMC drivers (e.g. the EmfModel class).
+		 */
+		loadCommaSeparatedProperty(properties, PROPERTY_DATA_URIS, this.dataURIs);
+		loadCommaSeparatedProperty(properties, PROPERTY_SCHEMA_URIS, this.schemaURIs);
+		loadPropertyValidateModel(properties);
+
+		this.customPrefixesMap.clear();
+		String sPrefixes = properties.getProperty(PROPERTY_PREFIXES, "").strip();
+		if (!sPrefixes.isEmpty()) {
+			for (String sItem : sPrefixes.split(",")) {
+				int idxEquals = sItem.indexOf('=');
+				if (idxEquals <= 0 || idxEquals == sItem.length() - 1) {
+					throw new IllegalArgumentException(String.format("Entry '%s' does not follow the prefix=uri format", sItem));
+				}
+
+				String sPrefix = sItem.substring(0, idxEquals);
+				String sURI = sItem.substring(idxEquals + 1);
+				customPrefixesMap.put(sPrefix, sURI);
+			}
+		}
+
+		this.languagePreference.clear();
+		String sLanguagePreference = properties.getProperty(PROPERTY_LANGUAGE_PREFERENCE, "").strip();
+		if (!sLanguagePreference.isEmpty()) {
+			for (String tag : sLanguagePreference.split(",")) {
+				tag = tag.strip();
+				if (isValidLanguageTag(tag)) {
+					this.languagePreference.add(tag);
+				} else {
+					throw new EolModelLoadingException(
+						new IllegalArgumentException(
+							String.format("'%s' is not a valid BCP 47 tag", tag)
+						), this);
+				}
+			}
+		}
+
+		load();
+		
+		// After Loading all scheme, data models and inferring the full model, validate
+		if (validationProperty.contains(VALIDATION_SELECTION_JENA)) {
+			try {
+				validateModel();
+			} catch (Exception e) {
+				throw new EolModelLoadingException(e, this);
+			}
+		}
+	}
+
+	protected void loadCommaSeparatedProperty(StringProperties properties, String propertyName, List<String> targetList) {
+		targetList.clear();
+		{
+			String sUris = properties.getProperty(propertyName, "").strip();
+			if (!sUris.isEmpty()) {
+				for (String uri : sUris.split(",")) {
+					targetList.add(uri.strip());
+				}
+			}
+		}
+	}
+
+	@Override
+	public boolean store(String location) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean store() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected Collection<RDFModelElement> allContentsFromModel() {
+		final List<RDFModelElement> elems = new ArrayList<>();
+
+		for (ResIterator it = model.listSubjects(); it.hasNext(); ) {
+			Resource stmt = it.next();
+			elems.add(createResource(stmt));
+		}
+		
+		return elems;
+	}
+
+	@Override
+	protected Collection<RDFModelElement> getAllOfTypeFromModel(String type)
+			throws EolModelElementTypeNotFoundException {
+		Resource typeR = getTypeResourceByName(type);
+
+		ResIterator itInstances = model.listResourcesWithProperty(RDF.type, typeR);
+		List<RDFModelElement> instances = new ArrayList<>();
+		while (itInstances.hasNext()) {
+			instances.add(createResource(itInstances.next()));
+		}
+
+		return instances;
+	}
+
 	protected Resource getTypeResourceByName(String type) throws EolModelElementTypeNotFoundException {
 		RDFQualifiedName qName = RDFQualifiedName.from(type, this::getNamespaceURI);
 
@@ -159,49 +297,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 
 		throw new EolModelElementTypeNotFoundException(this.getName(), type);
 	}
-	
-	//
-	// GET ALL ___ FROM MODEL
-	
-	@Override
-	public Collection<String> getAllTypeNamesOf(Object instance) {
-		List<String> types = new ArrayList<>();
-
-		if (instance instanceof RDFResource) {
-			RDFResource res = (RDFResource) instance;
-			for (RDFResource t : res.getTypes()) {
-				types.add(getQualifiedTypeName(t));
-			}
-		}
-
-		return types;
-	}
-	
-	@Override
-	protected Collection<RDFModelElement> allContentsFromModel() {
-		final List<RDFModelElement> elems = new ArrayList<>();
-
-		for (ResIterator it = model.listSubjects(); it.hasNext(); ) {
-			Resource stmt = it.next();
-			elems.add(createResource(stmt));
-		}
-		
-		return elems;
-	}
-
-	@Override
-	protected Collection<RDFModelElement> getAllOfTypeFromModel(String type)
-			throws EolModelElementTypeNotFoundException {
-		Resource typeR = getTypeResourceByName(type);
-
-		ResIterator itInstances = model.listResourcesWithProperty(RDF.type, typeR);
-		List<RDFModelElement> instances = new ArrayList<>();
-		while (itInstances.hasNext()) {
-			instances.add(createResource(itInstances.next()));
-		}
-
-		return instances;
-	}
 
 	@Override
 	protected Collection<RDFModelElement> getAllOfKindFromModel(String kind)
@@ -211,48 +306,11 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		return getAllOfTypeFromModel(kind);
 	}
 
-	//
-	// MODEL LIFE CYCLE (LOAD/DISPOSE/STORE)
-	
 	@Override
-	public void load(StringProperties properties, IRelativePathResolver resolver) throws EolModelLoadingException {
-		super.load(properties, resolver);
-
-		/*
-		 * This method assumes that the StringProperties replaces all previous
-		 * configuration of this RDFModel. This is the same as in other popular
-		 * EMC drivers (e.g. the EmfModel class).
-		 */
-		loadProperty(properties, PROPERTY_DATA_URIS, this.dataURIs);
-		loadProperty(properties, PROPERTY_SCHEMA_URIS, this.schemaURIs);
-		loadPropertyPrefixes(properties);
-		loadPropertyLanguagePreference(properties);
-		loadPropertyValidateModel(properties);
-
-		load();
-		
-		// After Loading all scheme, data models and inferring the full model, validate
-		if (validationProperty.contains(VALIDATION_SELECTION_JENA)) {
-			try {
-				validateModel();
-			} catch (Exception e) {
-				throw new EolModelLoadingException(e, this);
-			}
-		}
+	protected RDFResource createInstanceInModel(String type) throws EolModelElementTypeNotFoundException, EolNotInstantiableModelElementTypeException {
+		throw new UnsupportedOperationException();
 	}
 
-	private void loadProperty(StringProperties properties, String propertyName, List<String> targetList) {
-		targetList.clear();
-		{
-			String sUris = properties.getProperty(propertyName, "").strip();
-			if (!sUris.isEmpty()) {
-				for (String uri : sUris.split(",")) {
-					targetList.add(uri.strip());
-				}
-			}
-		}
-	}
-	
 	@Override
 	protected void loadModel() throws EolModelLoadingException {
 		if (!this.readOnLoad) {
@@ -281,7 +339,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 			}
 
 			//Create an OntModel to handle the data model being loaded or inferred from data and schema
-			this.model = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM_RULE_INF);
+			this.model = ModelFactory.createOntologyModel();
 			
 			if (reasonerType == ReasonerType.NONE) {
 				// Only the OntModel bits are added to the dataModel being loaded.
@@ -301,9 +359,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 			throw new EolModelLoadingException(ex, this);
 		}
 	}
-	
-	//
-	// VALIDATE MODEL
 
 	private void validateModel() throws Exception {
 		/*
@@ -317,7 +372,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 			// Throw error with a string containing the validity report 
 			String reportString = "The loaded model is not valid or not clean\n";
 			int i = 1;
-			for (Iterator o = modelValidityReport.getReports(); o.hasNext();) {
+			for (Iterator<Report> o = modelValidityReport.getReports(); o.hasNext();) {
 				ValidityReport.Report report = (ValidityReport.Report) o.next();
 				reportString = reportString.concat(" " + i + ", " + report.toString());
 				i++;
@@ -326,45 +381,45 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		}
 	}
 		
+	protected String validationProperty = VALIDATION_SELECTION_DEFAULT;
+	
+	private void loadPropertyValidateModel(StringProperties properties) {
+		validationProperty = properties.getProperty(RDFModel.PROPERTY_VALIDATE_MODEL, VALIDATION_SELECTION_JENA);
+	}
+	
+	public String getValidationProperty () {
+		return validationProperty;
+	}
+		
 	@Override
 	protected void disposeModel() {
 		model = null;
 	}
-	
-	// Store support coming soon...
+
 	@Override
-	public boolean store(String location) {
+	protected boolean deleteElementInModel(Object instance) throws EolRuntimeException {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public boolean store() {
-		throw new UnsupportedOperationException();
+	protected Object getCacheKeyForType(String type) throws EolModelElementTypeNotFoundException {
+		return getTypeResourceByName(type);
 	}
 
-	//
-	// JENA REASONER
+	@Override
+	public Collection<String> getAllTypeNamesOf(Object instance) {
+		List<String> types = new ArrayList<>();
 
-	public enum ReasonerType {
-		// TODO add to this list to cover reasoner types in the ReasonerRegistry Class
-		NONE, OWL_FULL;
+		if (instance instanceof RDFResource) {
+			RDFResource res = (RDFResource) instance;
+			for (RDFResource t : res.getTypes()) {
+				types.add(getQualifiedTypeName(t));
+			}
+		}
+
+		return types;
 	}
 
-	protected ReasonerType reasonerType = ReasonerType.NONE;
-
-	public ReasonerType getReasonerType() {
-		return reasonerType;
-	}
-
-	public void setReasonerType(ReasonerType rdfsReasonerType) {
-		this.reasonerType = rdfsReasonerType;
-	}
-	
-	//
-	// PROPERTY DATA URIS
-	
-	protected final List<String> dataURIs = new ArrayList<>();
-	
 	public List<String> getDataUris() {
 		return dataURIs;
 	}
@@ -374,56 +429,23 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		this.dataURIs.add(uri);
 	}
 
-	//
-	// PROPERTY SCHEMA URIS
-	
-	protected final List<String> schemaURIs = new ArrayList<>();
-	
 	public List<String> getSchemaUris() {
 		return schemaURIs;
 	}
-	
 
 	public void setSchemaUri(String uri) {
 		this.schemaURIs.clear();
 		this.schemaURIs.add(uri);
 	}
 
-
-	//
-	// PROPERTY PREFIXES
-	
-	/** 
-	 * One of the keys used to construct the first argument to
-	 * {@link #load(StringProperties, String)}.
-	 *
-	 * This key should be set to a comma-separated list of prefix=uri pairs that
-	 * should be added to the prefix->URI map of the loaded RDF resource. These
-	 * pairs will take precedence over existing pairs in the resource.
-	 */
-	protected final Map<String, String> customPrefixesMap = new HashMap<>();
-	
-	private void loadPropertyPrefixes (StringProperties properties) {
-		this.customPrefixesMap.clear();
-		String sPrefixes = properties.getProperty(PROPERTY_PREFIXES, "").strip();
-		if (!sPrefixes.isEmpty()) {
-			for (String sItem : sPrefixes.split(",")) {
-				int idxEquals = sItem.indexOf('=');
-				if (idxEquals <= 0 || idxEquals == sItem.length() - 1) {
-					throw new IllegalArgumentException(String.format("Entry '%s' does not follow the prefix=uri format", sItem));
-				}
-				String sPrefix = sItem.substring(0, idxEquals);
-				String sURI = sItem.substring(idxEquals + 1);
-				customPrefixesMap.put(sPrefix, sURI);
-			}
-		}
-	}
-	
 	public Map<String, String> getCustomPrefixesMap() {
 		return this.customPrefixesMap;
 	}
 	
-	
+	public List<String> getLanguagePreference() {
+		return languagePreference;
+	}
+
 	/**
 	 * <p>
 	 * Returns the URI associated to a prefix.
@@ -443,7 +465,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		return uri;
 	}
 
-	
 	/**
 	 * <p>
 	 * Returns a prefix associated with a namespace URI, if it exists.
@@ -463,76 +484,10 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		return model.getNsURIPrefix(namespaceURI);
 	}
 
-
-	//
-	// PROPERTY LANGUAGE PREFERENCE
-	
-
-	protected final List<String> languagePreference = new ArrayList<>();
-
-	private void loadPropertyLanguagePreference(StringProperties properties) throws EolModelLoadingException {
-		this.languagePreference.clear();
-		String sLanguagePreference = properties.getProperty(PROPERTY_LANGUAGE_PREFERENCE, "").strip();
-		if (!sLanguagePreference.isEmpty()) {
-			for (String tag : sLanguagePreference.split(",")) {
-				tag = tag.strip();
-				if (isValidLanguageTag(tag)) {
-					this.languagePreference.add(tag);
-				} else {
-					throw new EolModelLoadingException(
-						new IllegalArgumentException(
-							String.format("'%s' is not a valid BCP 47 tag", tag)
-						), this);
-				}
-			}
-		}
-	}
-	
-	public List<String> getLanguagePreference() {
-		return languagePreference;
-	}
-	
-
 	// Using Java's Locale class to check that tags conform to bcp47 structure
 	public static boolean isValidLanguageTag (String bcp47tag) {
 		boolean isValidBCP47 = !("und".equals(Locale.forLanguageTag(bcp47tag).toLanguageTag()));
 		return isValidBCP47;
 	}
-	
-	//
-	// PROPERTY JANA VALIDATE MODEL 
-	
-	protected String validationProperty = VALIDATION_SELECTION_DEFAULT;
-	
-	private void loadPropertyValidateModel(StringProperties properties) {
-		validationProperty = properties.getProperty(RDFModel.PROPERTY_VALIDATE_MODEL, VALIDATION_SELECTION_JENA);
-	}
-	
-	public String getValidationProperty () {
-		return validationProperty;
-	}
-	
-	//
-	// UNSUPPORTED OPERATIONS
-	
-	@Override
-	protected RDFResource createInstanceInModel(String type) throws EolModelElementTypeNotFoundException, EolNotInstantiableModelElementTypeException {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public void setElementId(Object instance, String newId) {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	protected boolean deleteElementInModel(Object instance) throws EolRuntimeException {
-		throw new UnsupportedOperationException();
-	}
-	
-	@Override
-	public Object getEnumerationValue(String enumeration, String label) throws EolEnumerationValueNotFoundException {
-		throw new UnsupportedOperationException();
-	}	
 
 }

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.jena.ontology.OntModel;
+import org.apache.jena.ontology.OntModelSpec;
 import org.apache.jena.rdf.model.InfModel;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -339,7 +340,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 			}
 
 			//Create an OntModel to handle the data model being loaded or inferred from data and schema
-			this.model = ModelFactory.createOntologyModel();
+			this.model = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM_RULE_INF);
 			
 			if (reasonerType == ReasonerType.NONE) {
 				// Only the OntModel bits are added to the dataModel being loaded.

--- a/tests/org.eclipse.epsilon.emc.rdf.dt.tests/src/org/eclipse/epsilon/emc/rdf/dt/tests/EclipseRDFModelUrlTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.dt.tests/src/org/eclipse/epsilon/emc/rdf/dt/tests/EclipseRDFModelUrlTest.java
@@ -164,7 +164,7 @@ public class EclipseRDFModelUrlTest extends EclipseProjectEnvTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);  // Throws model validity errors not related to path problems
 		return props;
 	}
 }

--- a/tests/org.eclipse.epsilon.emc.rdf.dt.tests/src/org/eclipse/epsilon/emc/rdf/dt/tests/EclipseRDFModelUrlTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.dt.tests/src/org/eclipse/epsilon/emc/rdf/dt/tests/EclipseRDFModelUrlTest.java
@@ -164,6 +164,7 @@ public class EclipseRDFModelUrlTest extends EclipseProjectEnvTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);
 		return props;
 	}
 }

--- a/tests/org.eclipse.epsilon.emc.rdf.dt.tests/src/org/eclipse/epsilon/emc/rdf/dt/tests/EclipseRDFModelUrlTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.dt.tests/src/org/eclipse/epsilon/emc/rdf/dt/tests/EclipseRDFModelUrlTest.java
@@ -164,7 +164,7 @@ public class EclipseRDFModelUrlTest extends EclipseProjectEnvTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);  // Throws model validity errors not related to path problems
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);  // Throws model validity errors for computer with 2 motherboards (expected to fail Jena Validation)
 		return props;
 	}
 }

--- a/tests/org.eclipse.epsilon.emc.rdf.dt.tests/src/org/eclipse/epsilon/emc/rdf/dt/tests/EclipseRDFModelUrlTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.dt.tests/src/org/eclipse/epsilon/emc/rdf/dt/tests/EclipseRDFModelUrlTest.java
@@ -164,7 +164,12 @@ public class EclipseRDFModelUrlTest extends EclipseProjectEnvTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);  // Throws model validity errors for computer with 2 motherboards (expected to fail Jena Validation)
+
+		/*
+		 * Throws model validity errors for computer with 2 motherboards (expected to
+		 * fail Jena validation).
+		 */
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);
 		return props;
 	}
 }

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/resources/OWL/owlDemoData_valid.ttl
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/resources/OWL/owlDemoData_valid.ttl
@@ -1,0 +1,19 @@
+@prefix : <urn:x-hp:eg/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+:alienBox51 a :GamingComputer .
+
+:bigName42 a :Computer ;
+    :bundle :binNameSpecialBundle ;
+    :motherBoard :bigNameSpecialMB .
+
+:whiteBoxZX a :Computer ;
+    :bundle :actionPack ;
+    :motherBoard :nForce .
+
+:actionPack a :GameBundle .
+
+:bigNameSpecialMB owl:differentFrom :nForce2 .
+
+:unknownMB :hasGraphics :gamingGraphics .
+

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/CommonQueryTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/CommonQueryTest.java
@@ -201,8 +201,8 @@ public class CommonQueryTest<T extends RDFModel> {
 			"foaf:Person",
 			model.getTypeNameOf(firstPerson));
 		
-		assertEquals("The model should only report the Person type and the rdfs Resource",
-				new HashSet<>(Arrays.asList("foaf:Person", "rdfs:Resource")),
+		assertEquals("The model should only report the foaf Person, rdfs Resource and owl Thing",
+				new HashSet<>(Arrays.asList("foaf:Person", "rdfs:Resource", "owl:Thing")),
 				new HashSet<>(model.getAllTypeNamesOf(firstPerson)));		
 	}
 

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
@@ -97,7 +97,7 @@ public class MOF2RDFModelOWLReasonerTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);
 		model.load(props);
 
 		this.context = new EolContext();

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
@@ -97,6 +97,7 @@ public class MOF2RDFModelOWLReasonerTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);
 		model.load(props);
 
 		this.context = new EolContext();

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelOWLReasonerTest.java
@@ -101,7 +101,7 @@ public class RDFModelOWLReasonerTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);  // There is a known issues in the model required for tests
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);  // There is a known issues in the model required for tests
 		model.load(props);
 
 		this.context = new EolContext();

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelOWLReasonerTest.java
@@ -101,6 +101,7 @@ public class RDFModelOWLReasonerTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);
 		model.load(props);
 
 		this.context = new EolContext();

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelOWLReasonerTest.java
@@ -101,7 +101,7 @@ public class RDFModelOWLReasonerTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, false);  // There is a known issues in the model required for tests
 		model.load(props);
 
 		this.context = new EolContext();

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelOWLReasonerTest.java
@@ -101,7 +101,9 @@ public class RDFModelOWLReasonerTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, schemaModelUri);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, languagePreference);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);  // There is a known issues in the model required for tests
+
+		// There is a known issue in the model required for tests
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);
 		model.load(props);
 
 		this.context = new EolContext();

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
@@ -1,0 +1,82 @@
+/********************************************************************************
+ * Copyright (c) 2024 University of York
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Antonio Garcia-Dominguez - initial API and implementation
+ ********************************************************************************/
+package org.eclipse.epsilon.emc.rdf;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Collection;
+
+import org.eclipse.epsilon.common.util.StringProperties;
+import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
+import org.eclipse.epsilon.eol.execute.context.EolContext;
+import org.junit.After;
+import org.junit.Test;
+
+public class RDFModelValidationTest {
+
+	private static final String OWL_DEMO_DATAMODEL_INVALID = "resources/OWL/owlDemoData.ttl";
+	private static final String OWL_DEMO_DATAMODEL_VALID = "resources/OWL/owlDemoData_valid.ttl";
+	private static final String OWL_DEMO_SCHEMAMODEL = "resources/OWL/owlDemoSchema.ttl";
+
+	private static final String LANGUAGE_PREFERENCE_EN_STRING = "en";
+	private static final String URI_BIGNAME42 = "urn:x-hp:eg/bigName42";
+	private static final String URI_ALIENBOX51 = "urn:x-hp:eg/alienBox51";
+	private static final String URI_WHITEBOX = "urn:x-hp:eg/whiteBoxZX";
+
+	private RDFModel model;
+	private EolContext context;
+
+	@Test
+	public void loadInvalidModel() {
+
+		try {
+			loadModel(OWL_DEMO_DATAMODEL_INVALID);
+		} catch (EolModelLoadingException e) {
+			String sErrors = e.getMessage();
+			assertTrue("The model loaded should FAIL validation (6 errors relating to BigName42 having 2 motherboards)",
+					sErrors.contains("Error whilst loading model null: The loaded model is not valid or not clean"));
+		}
+
+	}
+
+	@Test
+	public void loadValidModel() throws EolModelLoadingException {
+		try {
+			loadModel(OWL_DEMO_DATAMODEL_VALID);
+		} catch (EolModelLoadingException e) {
+			String sErrors = e.getMessage();
+			System.out.println(sErrors);
+			assertFalse("The model loaded should NOT FAIL validation",
+					sErrors.contains("Error whilst loading model null: The loaded model is not valid or not clean"));
+		}
+	}
+
+	// Functions not tests
+
+	protected void loadModel(String dataModelUri) throws EolModelLoadingException {
+		this.model = new RDFModel();
+		StringProperties props = new StringProperties();
+		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
+		props.put(RDFModel.PROPERTY_SCHEMA_URIS, OWL_DEMO_SCHEMAMODEL);
+		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, LANGUAGE_PREFERENCE_EN_STRING);
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, true); // There is a known issues in the model required for tests
+		model.load(props);
+
+		this.context = new EolContext();
+	}
+
+}

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
@@ -12,19 +12,11 @@
  ********************************************************************************/
 package org.eclipse.epsilon.emc.rdf;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.Collection;
-
 import org.eclipse.epsilon.common.util.StringProperties;
 import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
-import org.eclipse.epsilon.eol.execute.context.EolContext;
-import org.junit.After;
 import org.junit.Test;
 
 public class RDFModelValidationTest {
@@ -34,26 +26,20 @@ public class RDFModelValidationTest {
 	private static final String OWL_DEMO_SCHEMAMODEL = "resources/OWL/owlDemoSchema.ttl";
 
 	private static final String LANGUAGE_PREFERENCE_EN_STRING = "en";
-	private static final String URI_BIGNAME42 = "urn:x-hp:eg/bigName42";
-	private static final String URI_ALIENBOX51 = "urn:x-hp:eg/alienBox51";
-	private static final String URI_WHITEBOX = "urn:x-hp:eg/whiteBoxZX";
 
 	private RDFModel model;
-	private EolContext context;
 
 	@Test
 	public void loadInvalidModel() {
 
 		try {
 			loadModel(OWL_DEMO_DATAMODEL_INVALID);
+			fail("An exception was expected");
 		} catch (EolModelLoadingException e) {
 			String sErrors = e.getMessage();
 			assertTrue("The model loaded should FAIL validation (6 errors relating to BigName42 having 2 motherboards)",
 					sErrors.contains("not valid"));
-			return;
 		}
-		fail();
-
 	}
 
 	@Test
@@ -71,8 +57,6 @@ public class RDFModelValidationTest {
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, LANGUAGE_PREFERENCE_EN_STRING);
 		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_JENA);
 		model.load(props);
-
-		this.context = new EolContext();
 	}
 
 }

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
@@ -72,7 +72,7 @@ public class RDFModelValidationTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, OWL_DEMO_SCHEMAMODEL);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, LANGUAGE_PREFERENCE_EN_STRING);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_DEFAULT); // There is a known issues in the model required for tests
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_JENA); // There is a known issues in the model required for tests
 		model.load(props);
 
 		this.context = new EolContext();

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
@@ -14,6 +14,7 @@ package org.eclipse.epsilon.emc.rdf;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -48,20 +49,16 @@ public class RDFModelValidationTest {
 		} catch (EolModelLoadingException e) {
 			String sErrors = e.getMessage();
 			assertTrue("The model loaded should FAIL validation (6 errors relating to BigName42 having 2 motherboards)",
-					sErrors.contains("Error whilst loading model null: The loaded model is not valid or not clean"));
+					sErrors.contains("not valid"));
+			return;
 		}
+		fail();
 
 	}
 
 	@Test
 	public void loadValidModel() throws EolModelLoadingException {
-		try {
-			loadModel(OWL_DEMO_DATAMODEL_VALID);
-		} catch (EolModelLoadingException e) {
-			String sErrors = e.getMessage();
-			assertFalse("The model loaded should NOT FAIL validation",
-					sErrors.contains("Error whilst loading model null: The loaded model is not valid or not clean"));
-		}
+		loadModel(OWL_DEMO_DATAMODEL_VALID);
 	}
 
 	// Functions not tests
@@ -72,7 +69,7 @@ public class RDFModelValidationTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, OWL_DEMO_SCHEMAMODEL);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, LANGUAGE_PREFERENCE_EN_STRING);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_JENA); // There is a known issues in the model required for tests
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_JENA);
 		model.load(props);
 
 		this.context = new EolContext();

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/RDFModelValidationTest.java
@@ -59,7 +59,6 @@ public class RDFModelValidationTest {
 			loadModel(OWL_DEMO_DATAMODEL_VALID);
 		} catch (EolModelLoadingException e) {
 			String sErrors = e.getMessage();
-			System.out.println(sErrors);
 			assertFalse("The model loaded should NOT FAIL validation",
 					sErrors.contains("Error whilst loading model null: The loaded model is not valid or not clean"));
 		}
@@ -73,7 +72,7 @@ public class RDFModelValidationTest {
 		props.put(RDFModel.PROPERTY_DATA_URIS, dataModelUri);
 		props.put(RDFModel.PROPERTY_SCHEMA_URIS, OWL_DEMO_SCHEMAMODEL);
 		props.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, LANGUAGE_PREFERENCE_EN_STRING);
-		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, true); // There is a known issues in the model required for tests
+		props.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_DEFAULT); // There is a known issues in the model required for tests
 		model.load(props);
 
 		this.context = new EolContext();


### PR DESCRIPTION

**Housekeeping RDFModel**
- [x] Collected the property variables/methods together
I added some comments to identify the sections/components more clearly.

**RDFModel**
- [x] Add validation property (boolean) to RDFModel -- default on (true)
- [x] Add accessor/mutator for the validation property
- [x] Add property loading process for validation

**RDFModelConfigurationDialog**
- [x] Add UI element (check box) to set the validation of models on load
- [x] Add validation property storing process
- [x] Add validation property recall process

There is only a check box for validation (on/off), this turns Jena's validation process on/off. Failing the Validation throws an exception which stops the loading process. In the future there may be a need for one or more validation processes a text box will replace the boolean check box, so a list (CSV) of validations can be given.

**RDFModel**
- [x] Add validation method
- [x] Capture validation errors with an EolModelLoadingException
- [x] Insert validation method call into the load process

The existing method for validation could be replaced or overridden in future revisions to enable more complex validation techniques. 

**Test**

- [x] Add test to the OWLDemoData that runs validation to detect issues with MaxCardinality.

Added a new test file for testing validation. One test checks that the validation error message contains some expected string for the invalid OWL Data Model. The second test validates a corrected version of the OWL Data Model.

[Last revision] _Change the internal property representation for validation to a text string, which can be used for a wider scope of validation processes._

- [x] Change the property handling (internally) from boolean/string to only strings

