### PR TITLE
17 add the ability to save rdf models

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,16 +160,24 @@ Data and schema models can be loaded using `platform:/` URLs when using the driv
 
 ### Data models, schema models and reasoners
 
-RDF models are loaded as Ontology Resource Models with Jena's default OWL reasoner.
+RDF data and schema models (configured URIs) are handled using a Jena `Datasets`. The models in the datasets are combined into `Union models`, separate union models are used for the data and schema models. An `Inference model` is created from the union models and presented as an `Ontology model` in the EMC-REF driver.
+
+RDF models are presented as an Ontology Resource Model with Jena's default OWL reasoner.
 This reasoner infers OWL concepts onto an RDF data model when it is loaded.
 
 In order to support OWL inferencing, the `RDF Model` configuration dialog is divided into two sections:
 
-* "Data Model URLs to load": each of the elements in the list is loaded and merged into a single RDF data model.
-* "Schema Model URLs to load": each element is merged into a single RDF schema model.
+* "Data Model URLs to load": each of the elements in the list is loaded and merged into a single RDF data model (union model).
+* "Schema Model URLs to load": each element is merged into a single RDF schema model (union model).
 
 The resulting RDF data and schema models are then processed by Jena's reasoner using the default OWL settings.
-The inferred model is then used by Epsilon for querying.
+The inferred model is then wrapped as an ontology model which used by Epsilon for querying.
+
+### Storing RDF models
+
+The store method is available on the EMC-RDF driver to save RDF Models to the same or different URI. When the store method is called, all the data models (not schema) are written to storage. A new URI location (folder) can be provided to the store method to save all data models to a new location. When saving data models to a new location their original filenames are used with the new location URI prefixed. 
+
+Jena's API attempts to detect the language of the RDF data loaded from the original URI; the same language is used, with Turtle as a fall-back. It is worth noting that when a data model file containing comments is loaded, the comments are lost when the data model is stored.
 
 ### MOF2RDF models
 

--- a/README.md
+++ b/README.md
@@ -160,24 +160,27 @@ Data and schema models can be loaded using `platform:/` URLs when using the driv
 
 ### Data models, schema models and reasoners
 
-RDF data and schema models (configured URIs) are handled using a Jena `Datasets`. The models in the datasets are combined into `Union models`, separate union models are used for the data and schema models. An `Inference model` is created from the union models and presented as an `Ontology model` in the EMC-REF driver.
-
-RDF models are presented as an Ontology Resource Model with Jena's default OWL reasoner.
-This reasoner infers OWL concepts onto an RDF data model when it is loaded.
+RDF data and schema models (configured URIs) are handled using Jena `Dataset`s.
+The models in the datasets are combined into *union models*: separate union models are used for the data and schema models.
+An *inference model* is created from the union models with Jena's default OWL reasoner, and presented as an *ontology model* in the EMC-REF driver.
 
 In order to support OWL inferencing, the `RDF Model` configuration dialog is divided into two sections:
 
-* "Data Model URLs to load": each of the elements in the list is loaded and merged into a single RDF data model (union model).
-* "Schema Model URLs to load": each element is merged into a single RDF schema model (union model).
+* "Data Model URLs to load": the elements are merged into a single RDF data model, as a union model.
+* "Schema Model URLs to load": the elements are merged into a single RDF schema model, as a union model.
 
 The resulting RDF data and schema models are then processed by Jena's reasoner using the default OWL settings.
 The inferred model is then wrapped as an ontology model which used by Epsilon for querying.
 
 ### Storing RDF models
 
-The store method is available on the EMC-RDF driver to save RDF Models to the same or different URI. When the store method is called, all the data models (not schema) are written to storage. A new URI location (folder) can be provided to the store method to save all data models to a new location. When saving data models to a new location their original filenames are used with the new location URI prefixed. 
+The `store` method is available on the EMC-RDF driver to save RDF Models to the same or different URIs.
+When `store` is called, all the data models (not schema) are written to storage.
+A new URI location (folder) can be provided to the store method to save all data models to a new location.
+When saving data models to a new location, their original filenames are used with the new location URI prefixed.
 
-Jena's API attempts to detect the language of the RDF data loaded from the original URI; the same language is used, with Turtle as a fall-back. It is worth noting that when a data model file containing comments is loaded, the comments are lost when the data model is stored.
+Jena's API attempts to detect the language of the RDF data loaded from the original URI: the same language is used, with Turtle as a fall-back.
+It is worth noting that when a data model file containing comments is loaded, the comments are lost when the data model is stored.
 
 ### MOF2RDF models
 

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -264,10 +264,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		}
 	}
 	
-	private String locationPrefix;
-	Function <String, String> newLocation = uri -> locationPrefix + uri.substring(uri.lastIndexOf('/') + 1);
-	Function <String, String> sameLocation = uri -> uri;
-	
 	private boolean store(Function <String, String> mapper) {		
 		for (String uri : dataURIs) {
 			try {
@@ -291,8 +287,8 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		{
 			location = location.concat("/");
 		}			
-		locationPrefix = location;
-		return store(newLocation);
+		String locationPrefix = location;
+		return store(uri -> locationPrefix + uri.substring(uri.lastIndexOf('/') + 1));
 	}
 
 	@Override
@@ -301,7 +297,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 		 * Save back to original URI iterate over URIs, write the dataset named models
 		 * back to storage with format detected by Jena
 		 */
-		return store(sameLocation);
+		return store(uri -> uri);
 	}
 
 	@Override

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -95,10 +95,10 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 
 	
 	protected final List<String> schemaURIs = new ArrayList<>();
-	protected Dataset schemaModelSet;	// DefaultModel empty, using NamedModels
+	protected Dataset schemaModelSet = DatasetFactory.create();		// DefaultModel empty, using NamedModels
 	
 	protected final List<String> dataURIs = new ArrayList<>();
-	protected Dataset dataModelSet;		// DefaultModel empty, using NamedModels
+	protected Dataset dataModelSet = DatasetFactory.create();		// DefaultModel empty, using NamedModels
 	
 	protected OntModel model;	// read-only
 
@@ -248,27 +248,32 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	}
 		
 	private void storeDataNamedModel (String namedModelURI, String saveLocationURI) throws IOException {
-		// Assumes the NamedModelURI is for a model in the dataset and locationURI be saved to
+		// NamedModelURI is a model in the dataset and locationURI be saved to
 	
-		Model modelToSave = dataModelSet.getNamedModel(namedModelURI);
-		Lang lang = RDFDataMgr.determineLang(namedModelURI, namedModelURI, null);
-		
-	    try (OutputStream out = new FileOutputStream(saveLocationURI)) {
-	    	RDFDataMgr.write(out, modelToSave, lang);
-	    	out.close();	
-	    } 
+		if (dataModelSet.containsNamedModel(namedModelURI))
+		{
+			Model modelToSave = dataModelSet.getNamedModel(namedModelURI);
+
+			Lang lang = RDFDataMgr.determineLang(namedModelURI, namedModelURI, Lang.TTL);  // Hint becomes default
+
+			try (OutputStream out = new FileOutputStream(saveLocationURI)) {
+				RDFDataMgr.write(out, modelToSave, lang);
+				out.close();
+			}
+		}
 	}
 	
 	@Override
 	public boolean store(String location) {
-		// Save models to new URIs using the location given and namedModel filename
-		// iterate over URIs, write the dataset named models back to new storage URI with format detected by Jena
+		/*
+		 * Save models to new URIs using the location given and namedModel filename
+		 * iterate over URIs, write the dataset named models back to new storage URI
+		 * with format detected by Jena
+		 */
 		
-		System.out.println("location: " + location);
 		if (!location.endsWith("/"))
 		{
-			location = location + "/";
-			System.out.println("fixed locations: " + location);
+			location = location.concat("/");
 		}			
 		
 		for (String uri : dataURIs) {
@@ -277,24 +282,24 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 			try {
 				storeDataNamedModel(uri, newUri);
 			} catch (IOException e) {
-				// TODO Auto-generated catch block
 				e.printStackTrace();
 				return false;
 			}			
-			//System.out.println("dataURI: " + uri + "dataURI file name: " + fileName	+ "new Location and fileName: " + newUri );			
 		}
 		return true;
 	}
 
 	@Override
 	public boolean store() {
-		// Save back to original URI
-		// iterate over URIs, write the dataset named models back to storage with format detected by Jena
+		/*
+		 * Save back to original URI iterate over URIs, write the dataset named models
+		 * back to storage with format detected by Jena
+		 */
+
 		for (String uri : dataURIs) {
 			try {
 				storeDataNamedModel(uri, uri);
 			} catch (IOException e) {
-				// TODO Auto-generated catch block
 				e.printStackTrace();
 				return false;
 			}

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -268,7 +268,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	Function <String, String> newLocation = uri -> locationPrefix + uri.substring(uri.lastIndexOf('/') + 1);
 	Function <String, String> sameLocation = uri -> uri;
 	
-	protected boolean store(Function <String, String> mapper) {		
+	private boolean store(Function <String, String> mapper) {		
 		for (String uri : dataURIs) {
 			try {
 				storeDataNamedModel(uri, mapper.apply(uri));

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFModel.java
@@ -100,7 +100,7 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 	protected final List<String> dataURIs = new ArrayList<>();
 	protected Dataset dataModelSet;		// DefaultModel empty, using NamedModels
 	
-	protected OntModel model;
+	protected OntModel model;	// read-only
 
 	public RDFModel() {
 		this.propertyGetter = new RDFPropertyGetter(this);
@@ -381,8 +381,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 			if (dataURIs.isEmpty()) {
 				throw new IllegalStateException("No file path has been set");
 			}
-
-			// Read all the URIs into an integrated model
 			
 			schemaModelSet = DatasetFactory.createNamed(schemaURIs);
 			Model schemaUnionModel = schemaModelSet.getUnionModel(); // READ-ONLY
@@ -406,13 +404,6 @@ public class RDFModel extends CachedModel<RDFModelElement> {
 				this.model = ModelFactory.createOntologyModel(OntModelSpec.OWL_DL_MEM_RULE_INF, infmodel);
 			}
 
-		// Copy the Name prefix maps from the loaded Model dataModel to the new OntModel dataModel representation
-		//	May not need this now...
-			/* 
-			for (Entry<String, String> e : dataModel.getNsPrefixMap().entrySet()) {
-				this.model.setNsPrefix(e.getKey(), e.getValue());
-			}
-			*/
 		} catch (Exception ex) {
 			throw new EolModelLoadingException(ex, this);
 		}

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/StoreModelTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/StoreModelTest.java
@@ -1,0 +1,290 @@
+/********************************************************************************
+ * Copyright (c) 2024 University of York
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Antonio Garcia-Dominguez - initial API and implementation
+ ********************************************************************************/
+package org.eclipse.epsilon.emc.rdf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.stream.Stream;
+
+import org.eclipse.epsilon.common.util.StringProperties;
+import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
+import org.eclipse.epsilon.eol.models.Model;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StoreModelTest {
+
+	private static final String LANGUAGE_PREFERENCE_EN_STRING = "en";
+	
+	private static final String OWL_DEMO_FOLDER = "resources/OWL/";
+	private static final String OWL_DEMO_DATAMODEL_INVALID = OWL_DEMO_FOLDER + "owlDemoData.ttl";
+	private static final String OWL_DEMO_DATAMODEL_VALID = OWL_DEMO_FOLDER + "owlDemoData_valid.ttl";
+	private static final String OWL_DEMO_SCHEMAMODEL = OWL_DEMO_FOLDER + "owlDemoSchema.ttl";
+
+	private static final String SCRATCH_FOLDER_SHORT = "resource/storeTest";
+	private static final String SCRATCH_FOLDER = "resources/storeTest/";
+	private static final String SCRATCH_FOLDER_DATAMODEL_INVALID = SCRATCH_FOLDER + "owlDemoData.ttl";
+	private static final String SCRATCH_FOLDER_DATAMODEL_VALID = SCRATCH_FOLDER + "owlDemoData_valid.ttl";
+
+	private static final Path SCRATCH_PATH = Paths.get(SCRATCH_FOLDER);
+
+	private static final String TEST_STRING = "#THIS_TEXT_SHOULD_VANISH";
+
+	private RDFModel originalModel;
+
+	private RDFModel copyModel;
+
+	private RDFModel reloadCopyModel;
+	
+	@Before
+	public void setup() throws IOException {
+		originalModel = new RDFModel();
+		copyModel = new RDFModel();
+		reloadCopyModel = new RDFModel();
+		checkScratchFolder();
+	}
+
+	@After
+	public void postTest() throws IOException {
+		originalModel.dispose();
+		copyModel.dispose();
+		reloadCopyModel.dispose();
+		if (Files.exists(SCRATCH_PATH)) {
+			clearScratchFolder();
+		}
+	}
+
+	@Test
+	public void testEnvFileSystemTest() throws IOException {
+		Path source = Paths.get(OWL_DEMO_DATAMODEL_INVALID);
+		Path destination = copyFileToScratchFolder(source);
+		assertTrue("File copy failed", Files.exists(destination));
+		clearScratchFolder();
+		assertFalse("Clear Scratch Folder failed", Files.exists(destination));
+	}
+
+	@Test
+	public void loadSaveNewLocation() throws EolModelLoadingException, IOException {
+
+		loadOriginalModel();
+
+		originalModel.store(SCRATCH_FOLDER);
+
+		loadCopyModel();
+		
+		assertTrue("Missing file "+SCRATCH_FOLDER_DATAMODEL_VALID, 
+				Files.exists(Paths.get(SCRATCH_FOLDER_DATAMODEL_VALID)));
+		assertTrue("Missing file "+SCRATCH_FOLDER_DATAMODEL_INVALID, 
+				Files.exists(Paths.get(SCRATCH_FOLDER_DATAMODEL_INVALID)));
+		assertTrue("Size of the Original and Copy are not the same ",
+				originalModel.allContents().size() == copyModel.allContents().size());
+		
+	}
+	
+	@Test
+	public void loadSaveNewLocationBaduri() throws EolModelLoadingException, IOException {
+
+		loadOriginalModel();
+
+		originalModel.store(SCRATCH_FOLDER_SHORT);  // missing the last / 
+		
+		assertTrue("Missing file "+SCRATCH_FOLDER_DATAMODEL_VALID, 
+				Files.exists(Paths.get(SCRATCH_FOLDER_DATAMODEL_VALID)));
+		assertTrue("Missing file "+SCRATCH_FOLDER_DATAMODEL_INVALID, 
+				Files.exists(Paths.get(SCRATCH_FOLDER_DATAMODEL_INVALID)));
+		
+		loadCopyModel();
+		assertTrue("Size of the Original and Copy are not the same ",
+				originalModel.allContents().size() == copyModel.allContents().size());
+		
+	}
+	
+	@Test
+	public void loadSaveOverwrite() throws IOException, EolModelLoadingException {		
+		loadOriginalModel();				
+
+		// Copy the model files to the Scratch Folder for test
+		folderWalkCopy(OWL_DEMO_FOLDER, SCRATCH_FOLDER);
+
+		loadCopyModel();
+		assertTrue("Size of the Original and Copy are not the same ",originalModel.allContents().size() == copyModel.allContents().size());
+		
+		// Insert a comment at the end of both copied model files
+		Files.writeString(Paths.get(SCRATCH_FOLDER_DATAMODEL_VALID),TEST_STRING,StandardOpenOption.APPEND);
+		Files.writeString(Paths.get(SCRATCH_FOLDER_DATAMODEL_INVALID),TEST_STRING,StandardOpenOption.APPEND);
+		String dmvFileContentBefore = Files.readString(Paths.get(SCRATCH_FOLDER_DATAMODEL_VALID));
+		String dmiFileContentBefore = Files.readString(Paths.get(SCRATCH_FOLDER_DATAMODEL_INVALID));
+		assertTrue("The test String comment was not added.",dmvFileContentBefore.contains(TEST_STRING));
+		assertTrue("The test String comment was not added.",dmiFileContentBefore.contains(TEST_STRING));
+		
+		// Save the dataset and overwrite the copied model files.
+		copyModel.store();
+
+		// Check the comment on the end of the both files has been removed by the store()
+		String dmvFileContentAfter = Files.readString(Paths.get(SCRATCH_FOLDER_DATAMODEL_VALID));
+		String dmiFileContentAfter = Files.readString(Paths.get(SCRATCH_FOLDER_DATAMODEL_INVALID));
+		assertFalse("The test String comment was not added.",dmvFileContentAfter.contains(TEST_STRING));
+		assertFalse("The test String comment was not added.",dmiFileContentAfter.contains(TEST_STRING));
+		
+		// Check the stored models are the same size as the Copy before being stored.
+		reloadCopyModel();
+		
+		// The Copy and the Reloaded Copy after a save should be the same size
+		assertTrue("Size of the Copy and ReloadCopy are not the same ",
+				copyModel.allContents().size() == reloadCopyModel.allContents().size());
+
+	}
+	
+	@Test
+	public void callStoreOnModelWithNoURIs() throws IOException {
+		try {
+			originalModel.store();
+		} catch (Exception e) {
+			fail("store() with no URIs should do nothing" + e);
+		}
+		
+		try {
+			originalModel.store(SCRATCH_FOLDER);
+		} catch (Exception e) {
+			fail("store(String location) with no URIs should do nothing" + e);
+		}
+		
+		try (Stream<Path> walk = Files.walk(SCRATCH_PATH)) {
+			assertEquals("Walk counted unexpected files/folders", 1, walk.count());
+		}
+	}
+
+
+	@Test
+	public void storeModelBeforeLoadingOrCreating () throws IOException {
+		@SuppressWarnings("resource")
+		RDFModel newModel = new RDFModel();	
+		newModel.setDataUri(SCRATCH_FOLDER_DATAMODEL_VALID);
+		newModel.store();
+		Stream<Path> walk = Files.walk(SCRATCH_PATH);
+		assertTrue("A data URI property is set, but the dataset should not contain a Named Model for it", 
+				Files.notExists(Paths.get(SCRATCH_FOLDER_DATAMODEL_VALID)));
+		assertEquals("Walk counted unexpected files/folders", 1, walk.count());
+	}
+	
+	@Test
+	public void storeLocationModelBeforeLoadingOrCreating () throws IOException {
+		@SuppressWarnings("resource")
+		RDFModel newModel = new RDFModel();	
+		newModel.setDataUri(SCRATCH_FOLDER_DATAMODEL_VALID);
+		newModel.store(SCRATCH_FOLDER);
+		assertTrue("A data URI property is set, but the dataset should not contain a Named Model for it", 
+				Files.notExists(Paths.get(SCRATCH_FOLDER_DATAMODEL_VALID)));
+
+		try (Stream<Path> walk = Files.walk(SCRATCH_PATH)) {	
+			assertEquals("Walk counted unexpected files/folders", 1 , walk.count());
+		}
+	}
+
+	
+	
+
+//
+// FUNCTIONS NOT TESTS
+//
+
+	
+	private void loadOriginalModel() throws EolModelLoadingException {
+		StringProperties propsOriginalModel = new StringProperties();
+		propsOriginalModel.put(RDFModel.PROPERTY_DATA_URIS, OWL_DEMO_DATAMODEL_VALID 
+				+ "," + OWL_DEMO_DATAMODEL_INVALID);			
+		propsOriginalModel.put(RDFModel.PROPERTY_SCHEMA_URIS, OWL_DEMO_SCHEMAMODEL);
+		propsOriginalModel.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, LANGUAGE_PREFERENCE_EN_STRING);
+		propsOriginalModel.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);
+		originalModel.load(propsOriginalModel);
+	}
+	
+	private void reloadCopyModel() throws EolModelLoadingException {	
+		StringProperties propsReloadCopyModel = new StringProperties();
+		propsReloadCopyModel.put(RDFModel.PROPERTY_DATA_URIS, SCRATCH_FOLDER_DATAMODEL_VALID 
+				+ "," + SCRATCH_FOLDER_DATAMODEL_INVALID);			
+		propsReloadCopyModel.put(RDFModel.PROPERTY_SCHEMA_URIS, OWL_DEMO_SCHEMAMODEL);
+		propsReloadCopyModel.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, LANGUAGE_PREFERENCE_EN_STRING);
+		propsReloadCopyModel.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);
+		reloadCopyModel.load(propsReloadCopyModel);
+	}
+
+	private void loadCopyModel() throws EolModelLoadingException {
+		StringProperties propsCopyModel = new StringProperties();
+		propsCopyModel.put(RDFModel.PROPERTY_DATA_URIS, SCRATCH_FOLDER_DATAMODEL_VALID 
+				+ "," + SCRATCH_FOLDER_DATAMODEL_INVALID);			
+		propsCopyModel.put(RDFModel.PROPERTY_SCHEMA_URIS, OWL_DEMO_SCHEMAMODEL);
+		propsCopyModel.put(RDFModel.PROPERTY_LANGUAGE_PREFERENCE, LANGUAGE_PREFERENCE_EN_STRING);
+		propsCopyModel.put(RDFModel.PROPERTY_VALIDATE_MODEL, RDFModel.VALIDATION_SELECTION_NONE);
+		copyModel.load(propsCopyModel);
+	}
+
+	private void checkScratchFolder() throws IOException {
+		if (Files.notExists(SCRATCH_PATH)) {
+			Files.createDirectory(SCRATCH_PATH);
+		}
+	}
+
+	private void folderWalkCopy (String sourceFolder, String destinationFolder) throws IOException {
+		Path sourcePath = Paths.get(sourceFolder);
+		Stream<Path> walk = Files.walk(sourcePath).sorted();
+		Iterator<Path> itr = walk.iterator();
+		
+		while (itr.hasNext()) {
+			Path path = itr.next();
+			Path newPath = Paths.get(destinationFolder + path.getFileName());
+			Files.copy(path,newPath, StandardCopyOption.REPLACE_EXISTING);
+		}
+		
+	}
+	
+	private Path copyFileToScratchFolder(Path source) throws IOException {
+		checkScratchFolder();
+		Path destination = Paths.get(SCRATCH_FOLDER + source.getFileName());
+		Files.copy(source, destination, StandardCopyOption.REPLACE_EXISTING);
+		return destination;
+	}
+
+	private void deleteDirectoryAndFiles(Path deletePath) throws IOException {
+		try (Stream<Path> walk = Files.walk(deletePath)) {
+			walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+		}
+	}
+
+	private void clearScratchFolder() throws IOException {
+		if (Files.exists(SCRATCH_PATH)) {
+			deleteDirectoryAndFiles(SCRATCH_PATH);
+		}
+	}
+	
+	private void listFilesToConsole(Path path) throws IOException {		
+		try (Stream<Path> walk = Files.walk(path)) {
+			System.out.println("--File list--");
+			walk.forEach(p -> System.out.println(p));
+			System.out.println("-------------");
+		}
+	}
+}

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/StoreModelTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/StoreModelTest.java
@@ -17,14 +17,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
@@ -164,7 +162,7 @@ public class StoreModelTest {
 		try {
 			originalModel.store(scratch.getRoot().toString());
 		} catch (Exception e) {
-			fail("store(String location) with no URIs should not generate and Exception" + e);
+			fail("store(String location) with no URIs should not generate an Exception" + e);
 		}
 		
 		try (Stream<Path> walk = Files.walk(scratch.getRoot().toPath())) {

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/StoreModelTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/StoreModelTest.java
@@ -30,7 +30,6 @@ import java.util.stream.Stream;
 
 import org.eclipse.epsilon.common.util.StringProperties;
 import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
-import org.eclipse.epsilon.eol.models.Model;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +43,7 @@ public class StoreModelTest {
 	private static final String OWL_DEMO_DATAMODEL_VALID = OWL_DEMO_FOLDER + "owlDemoData_valid.ttl";
 	private static final String OWL_DEMO_SCHEMAMODEL = OWL_DEMO_FOLDER + "owlDemoSchema.ttl";
 
-	private static final String SCRATCH_FOLDER_SHORT = "resource/storeTest";
+	private static final String SCRATCH_FOLDER_SHORT = "resources/storeTest";
 	private static final String SCRATCH_FOLDER = "resources/storeTest/";
 	private static final String SCRATCH_FOLDER_DATAMODEL_INVALID = SCRATCH_FOLDER + "owlDemoData.ttl";
 	private static final String SCRATCH_FOLDER_DATAMODEL_VALID = SCRATCH_FOLDER + "owlDemoData_valid.ttl";
@@ -93,12 +92,14 @@ public class StoreModelTest {
 
 		originalModel.store(SCRATCH_FOLDER);
 
-		loadCopyModel();
+
 		
 		assertTrue("Missing file "+SCRATCH_FOLDER_DATAMODEL_VALID, 
 				Files.exists(Paths.get(SCRATCH_FOLDER_DATAMODEL_VALID)));
 		assertTrue("Missing file "+SCRATCH_FOLDER_DATAMODEL_INVALID, 
 				Files.exists(Paths.get(SCRATCH_FOLDER_DATAMODEL_INVALID)));
+
+		loadCopyModel();
 		assertTrue("Size of the Original and Copy are not the same ",
 				originalModel.allContents().size() == copyModel.allContents().size());
 		
@@ -109,7 +110,7 @@ public class StoreModelTest {
 
 		loadOriginalModel();
 
-		originalModel.store(SCRATCH_FOLDER_SHORT);  // missing the last / 
+		originalModel.store(SCRATCH_FOLDER_SHORT);  // missing the last / which should get fixed
 		
 		assertTrue("Missing file "+SCRATCH_FOLDER_DATAMODEL_VALID, 
 				Files.exists(Paths.get(SCRATCH_FOLDER_DATAMODEL_VALID)));


### PR DESCRIPTION
Added the ability to store data models.

- All data and schema models are loaded into a dataset, to form union models for inference
- Store writes out all the data models in the dataset to storage
- Store with a location URI treats the location as a folder, and writes data models as files (with the same name) to the new folder

Tests have been created

- Check the test environment file system, read/write access is needed for tests to work
- Loading/Storing data models to the same/new location
- Storing with a URI missing the last "/", which is corrected before storing
- Storing data models, when a URI is present but no model
- Storing data model when no URIs or models are present