### PR TITLE
31 fix use of maxcardinality in the absence of an explicit namespace prefix

### DIFF
--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/MOF2RDFResource.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/MOF2RDFResource.java
@@ -29,27 +29,36 @@ public class MOF2RDFResource extends RDFResource {
 
 		Collection<Object> value = super.getCollectionOfProperyValues(property, context);
 
-		// Perform Cardinality checks
 		final RDFQualifiedName pName = RDFQualifiedName.from(property, this.owningModel::getNamespaceURI);
 
-		// Disable this check to remove the maxCardinality limit on returned properties
-		// i.e. maxCardinality == null.
-		MaxCardinalityRestriction maxCardinality = RDFPropertyProcesses
-				.getPropertyStatementMaxCardinalityRestriction(pName, resource);
-
-		// Check collection of rawValues is less than the MaxCardinality and prune
-		if (null != maxCardinality) {
-			if (value.size() > maxCardinality.getMaxCardinality()) {
-				System.err.println("Property [" + pName + "] has a max cardinality "
-						+ maxCardinality.getMaxCardinality() + ", raw property values list contained " + value.size()
-						+ ".\n The list of raw property values has been pruned, it contained: " + value);
-
-				value = value.stream().limit(maxCardinality.getMaxCardinality()).collect(Collectors.toList());
-			}
-			if (maxCardinality.getMaxCardinality() == 1) {
-				// If the maximum cardinality is 1, return the single value (do not return a
-				// collection)
-				return value.isEmpty() ? null : value.iterator().next();
+		if(null == pName.prefix) {
+			// If no prefix was specified, ambiguity disables restriction checks and issues warning
+			context.getWarningStream().println(String.format(
+					"Ambiguous access to property with no prefix '%s': No restriction checks applied",
+					property));
+			return value;
+		}
+		else {
+			// Restriction checking on property 
+			
+			// Perform Cardinality checks
+			MaxCardinalityRestriction maxCardinality = RDFPropertyProcesses
+					.getPropertyStatementMaxCardinalityRestriction(pName, resource);
+	
+			// Check collection of rawValues is less than the MaxCardinality and prune
+			if (null != maxCardinality) {
+				if (value.size() > maxCardinality.getMaxCardinality()) {
+					//TODO move this warning to context.getWarningStream()
+					System.err.println("Property [" + pName + "] has a max cardinality "
+							+ maxCardinality.getMaxCardinality() + ", raw property values list contained " + value.size()
+							+ ".\n The list of raw property values has been pruned, it contained: " + value);
+	
+					value = value.stream().limit(maxCardinality.getMaxCardinality()).collect(Collectors.toList());
+				}
+				if (maxCardinality.getMaxCardinality() == 1) {
+					// If the maximum cardinality is 1, return the single value (not a collection)
+					return value.isEmpty() ? null : value.iterator().next();
+				}
 			}
 		}
 		return value;

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFPropertyProcesses.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFPropertyProcesses.java
@@ -57,7 +57,15 @@ public class RDFPropertyProcesses {
 		return propertyStatements;
 	}
 
-	protected record MaxCardRestrictedProperty(OntProperty property, MaxCardinalityRestriction restriction) implements Comparable<MaxCardRestrictedProperty> {
+	protected static class MaxCardRestrictedProperty implements Comparable<MaxCardRestrictedProperty> {
+		public final OntProperty property;
+		public final MaxCardinalityRestriction restriction;
+
+		public MaxCardRestrictedProperty(OntProperty property, MaxCardinalityRestriction restriction) {
+			this.property = property;
+			this.restriction = restriction;
+		}
+
 		public static MaxCardRestrictedProperty mostRestrictive(MaxCardRestrictedProperty mostRestrictive, OntProperty prop) {
 			for (ExtendedIterator<Restriction> itRestriction = prop.listReferringRestrictions(); itRestriction.hasNext();) {
 				Restriction restriction = itRestriction.next();

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFPropertyProcesses.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFPropertyProcesses.java
@@ -101,14 +101,16 @@ public class RDFPropertyProcesses {
 								MaxCardinalityRestriction maxCardinalityRestriction = restriction.asMaxCardinalityRestriction();
 								if (mostRestrictiveMaxCardinality == null) {
 									mostRestrictiveMaxCardinality = maxCardinalityRestriction;
+									mostRestrictiveMaxCardinalityProperty = prop;
 								} else {
 									if (mostRestrictiveMaxCardinality.getMaxCardinality() > maxCardinalityRestriction.getMaxCardinality()) {
 										mostRestrictiveMaxCardinality = maxCardinalityRestriction;
+										mostRestrictiveMaxCardinalityProperty = prop;
 									}
 								}
 							}
 						}
-						mostRestrictiveMaxCardinalityProperty = prop;
+						
 					}
 					
 				}

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFPropertyProcesses.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFPropertyProcesses.java
@@ -63,20 +63,18 @@ public class RDFPropertyProcesses {
 		// Gets all the propertyStatements and finds all the MaxCardinality restrictions, keeps the most restrictive (lowest maxCardinality)
 		MaxCardinalityRestriction mostRestrictiveMaxCardinality = null;
 		OntProperty mostRestrictiveMaxCardinalityProperty = null;
-		
 		OntResource ontResource = resource.as(OntResource.class);
-		
+
 		// TODO re-evaluate if it is OK to use listRDFTypes(true) if we've triggered reasoning
 		for (ExtendedIterator<Resource> itRDFType = ontResource.listRDFTypes(false); itRDFType.hasNext();) {
 			Resource rdfType = itRDFType.next();
 			OntClass ontClass = rdfType.as(OntClass.class);
 
 			for (ExtendedIterator<OntProperty> itProp = ontClass.listDeclaredProperties(); itProp.hasNext();) {
-
 				OntProperty prop = itProp.next();
-				if ((propertyName.localName.equals(prop.getLocalName()))
-						&& ((Objects.equals(propertyName.namespaceURI, prop.getNameSpace()))
-								|| (null == propertyName.prefix))) {
+				if (propertyName.localName.equals(prop.getLocalName())
+						&& (Objects.equals(propertyName.namespaceURI, prop.getNameSpace())
+								|| null == propertyName.prefix)) {
 
 					if (null != mostRestrictiveMaxCardinalityProperty) {
 						if (mostRestrictiveMaxCardinalityProperty.equals(prop)) {
@@ -86,18 +84,15 @@ public class RDFPropertyProcesses {
 							context.getWarningStream().println(String.format(
 									"Ambiguous access to property with no prefix '%s':"
 									+"\n Most restrictive Max Cardinality found was %s %s,"
-									+" but also found this a similar property %s",
+									+" but also found a similar property %s",
 									propertyName, mostRestrictiveMaxCardinalityProperty,
 									mostRestrictiveMaxCardinality.getMaxCardinality(), prop));
 						}
 					} else {
-
 						for (ExtendedIterator<Restriction> itRestriction = prop
 								.listReferringRestrictions(); itRestriction.hasNext();) {
-							
 							Restriction restriction = itRestriction.next();
 							if (restriction.isMaxCardinalityRestriction()) {
-								
 								MaxCardinalityRestriction maxCardinalityRestriction = restriction.asMaxCardinalityRestriction();
 								if (mostRestrictiveMaxCardinality == null) {
 									mostRestrictiveMaxCardinality = maxCardinalityRestriction;

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFPropertyProcesses.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFPropertyProcesses.java
@@ -25,6 +25,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.impl.PropertyImpl;
 import org.apache.jena.util.iterator.ExtendedIterator;
+import org.eclipse.epsilon.eol.execute.context.IEolContext;
 public class RDFPropertyProcesses {
 
 	private RDFPropertyProcesses() {
@@ -58,36 +59,77 @@ public class RDFPropertyProcesses {
 		return propertyStatements;
 	}
 
-	public static MaxCardinalityRestriction getPropertyStatementMaxCardinalityRestriction(RDFQualifiedName propertyName, Resource resource) {
+	public static MaxCardinalityRestriction getPropertyStatementMaxCardinalityRestriction(RDFQualifiedName propertyName, Resource resource, IEolContext context) {
 		// Gets all the propertyStatements and finds all the MaxCardinality restrictions, keeps the most restrictive (lowest maxCardinality)
 		MaxCardinalityRestriction mostRestrictiveMaxCardinality = null;
 
 		OntResource ontResource = resource.as(OntResource.class);
+		OntProperty mostRestrictiveMaxCardinalityProperty = null;
+		
+		System.out.println("\nMaxCardinalityRestriction check on " 
+				+ "\n resource: " + resource  
+				+ "\n propertyName: " + propertyName
+				+ "\n");
 
 		// TODO re-evaluate if it is OK to use listRDFTypes(true) if we've triggered reasoning
 		for (ExtendedIterator<Resource> itRDFType = ontResource.listRDFTypes(false); itRDFType.hasNext(); ) {
 			Resource rdfType = itRDFType.next();
 			OntClass ontClass = rdfType.as(OntClass.class);
+
 			for (ExtendedIterator<OntProperty> itProp = ontClass.listDeclaredProperties(); itProp.hasNext(); ) {
+				
 				OntProperty prop = itProp.next();
-				if (propertyName.localName.equals(prop.getLocalName()) && Objects.equals(propertyName.namespaceURI, prop.getNameSpace())) {
-					for (ExtendedIterator<Restriction> itRestriction = prop.listReferringRestrictions(); itRestriction.hasNext(); ) {
-						Restriction restriction = itRestriction.next();
-						if (restriction.isMaxCardinalityRestriction()) {
-							MaxCardinalityRestriction maxCardinalityRestriction = restriction.asMaxCardinalityRestriction();
-							if (mostRestrictiveMaxCardinality == null) {
-								mostRestrictiveMaxCardinality = maxCardinalityRestriction;
-							} else {
-								if (mostRestrictiveMaxCardinality.getMaxCardinality() > maxCardinalityRestriction.getMaxCardinality()) {
+				if ((propertyName.localName.equals(prop.getLocalName()))
+						&& ((Objects.equals(propertyName.namespaceURI, prop.getNameSpace()))
+								|| (null == propertyName.prefix))) {
+
+					if (null != mostRestrictiveMaxCardinalityProperty) {
+						// You've run into ambiguity around the name of the property - raise a warning
+                        if (mostRestrictiveMaxCardinalityProperty.equals(prop)) {
+                            // same property, don't need to look at it again                       	
+                        	System.out.println("  Duplicate (skip) > "
+                            + "(mostRestrictiveMaxCardinalityProperty) " + mostRestrictiveMaxCardinalityProperty 
+                            + " == "
+                            + prop + " (property)");
+                          } else {
+  						   // You've run into ambiguity around the name of the property - raise a warning
+                        	System.out.println("  Ambiguous > " 
+                                    + "(mostRestrictiveMaxCardinalityProperty) " + mostRestrictiveMaxCardinalityProperty 
+                                    + " == "
+                                    + prop + " (property)");
+      						context.getWarningStream().println(String.format(
+    								"Ambiguous access to property with no prefix '%s': most restrictive Max Cardinality found was %s",
+    								mostRestrictiveMaxCardinality.getMaxCardinality(), propertyName));
+                          }
+					} else {
+					
+						System.out.println("  Search restrictions on (ITR) property > " + prop.toString() ); 
+						System.out.println("	localName: " + propertyName.localName + " : " +  prop.getLocalName());
+						System.out.println("	nameSpace: " + propertyName.namespaceURI + " : " + prop.getNameSpace());
+						System.out.println("	   prefix: " + propertyName.prefix );
+						
+						for (ExtendedIterator<Restriction> itRestriction = prop.listReferringRestrictions(); itRestriction
+								.hasNext();) {
+							Restriction restriction = itRestriction.next();
+							if (restriction.isMaxCardinalityRestriction()) {
+								MaxCardinalityRestriction maxCardinalityRestriction = restriction
+										.asMaxCardinalityRestriction();
+								if (mostRestrictiveMaxCardinality == null) {
 									mostRestrictiveMaxCardinality = maxCardinalityRestriction;
+								} else {
+									if (mostRestrictiveMaxCardinality.getMaxCardinality() > maxCardinalityRestriction
+											.getMaxCardinality()) {
+										mostRestrictiveMaxCardinality = maxCardinalityRestriction;										
+									}
 								}
 							}
 						}
+						mostRestrictiveMaxCardinalityProperty = prop;	
 					}
 				}
-			}
-		}
 
+			}
+		}	
 		return mostRestrictiveMaxCardinality;
 	}
 

--- a/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFQualifiedName.java
+++ b/bundles/org.eclipse.epsilon.emc.rdf/src/org/eclipse/epsilon/emc/rdf/RDFQualifiedName.java
@@ -13,8 +13,11 @@
 package org.eclipse.epsilon.emc.rdf;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+
+import org.apache.jena.ontology.OntProperty;
 
 /**
  * <p>
@@ -94,6 +97,11 @@ public class RDFQualifiedName {
 	
 	public RDFQualifiedName withLanguageTag(String newLanguageTag) {
 		return new RDFQualifiedName(prefix, namespaceURI, localName, newLanguageTag);
+	}
+
+	public boolean matches(OntProperty prop) {
+		return localName.equals(prop.getLocalName())
+			&& (null == prefix || Objects.equals(namespaceURI, prop.getNameSpace()));
 	}
 
 	@Override

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tycho.version>4.0.3</tycho.version>
     <tycho.scmUrl>scm:git:https://github.com/epsilonlabs/emc-rdf.git</tycho.scmUrl>
-    <java.source.version>17</java.source.version>
+    <java.source.version>11</java.source.version>
     <java.target.version>11</java.target.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <tycho.version>4.0.3</tycho.version>
     <tycho.scmUrl>scm:git:https://github.com/epsilonlabs/emc-rdf.git</tycho.scmUrl>
-    <java.source.version>11</java.source.version>
+    <java.source.version>17</java.source.version>
     <java.target.version>11</java.target.version>
   </properties>
 

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/CommonQueryTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/CommonQueryTest.java
@@ -16,6 +16,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -78,6 +80,8 @@ public class CommonQueryTest<T extends RDFModel> {
 
 		this.pGetter = model.getPropertyGetter();
 		this.context = new EolContext();
+		ByteArrayOutputStream errorBOS = new ByteArrayOutputStream();
+		context.setWarningStream(new PrintStream(errorBOS));
 	}
 
 	@After

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelAmbiguousPropertyTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelAmbiguousPropertyTest.java
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (c) 2024 University of York
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Antonio Garcia-Dominguez - initial API and implementation
+ ********************************************************************************/
+package org.eclipse.epsilon.emc.rdf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+import org.eclipse.epsilon.eol.execute.context.EolContext;
+import org.eclipse.epsilon.eol.execute.introspection.IPropertyGetter;
+import org.junit.Test;
+
+public class MOF2RDFModelAmbiguousPropertyTest {
+
+	private static final String TTL = "resources/ambiguous-name.ttl";
+
+	@Test
+	public void nameIsAmbiguous() throws Exception {
+		try (MOF2RDFModel model = new MOF2RDFModel()) {
+			model.setDataUri(TTL);
+			model.load();
+
+			RDFResource elem = model.getElementById("http://example.org/#green-goblin");
+			IPropertyGetter pGetter = model.getPropertyGetter();
+
+			EolContext context = new EolContext();
+			ByteArrayOutputStream bOS = new ByteArrayOutputStream();
+			context.setWarningStream(new PrintStream(bOS));
+			Collection<?> names = (Collection<?>) pGetter.invoke(elem, "name", context);
+
+			// We get both names, and a warning around ambiguity
+			assertEquals("Both names should be reported", 2, names.size());
+
+			String warningText = bOS.toString(StandardCharsets.UTF_8);
+			assertTrue("A warning around an ambiguous property access should have been reported",
+				warningText.toLowerCase().contains("ambiguous"));
+			assertTrue("The FOAF prefix should be mentioned",
+				warningText.contains("http://xmlns.com/foaf/0.1/"));
+			assertTrue("The example prefix should be mentioned",
+					warningText.contains("http://example.org/somethingElse/"));
+		}
+	}
+	
+}

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
@@ -78,7 +78,6 @@ public class MOF2RDFModelOWLReasonerTest {
 		String sErrors = errors.toString();
 		assertTrue("A warning should be raised for the raw property values exceeding the max cardinality",
 				sErrors.contains("The list of raw property values has been pruned"));
-		System.err.println(sErrors);
 	}
 
 	@Test

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Collection;
 
 import org.eclipse.epsilon.common.util.StringProperties;
 import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
@@ -56,9 +57,28 @@ public class MOF2RDFModelOWLReasonerTest {
 		loadModelDefaults();
 		RDFResource element = model.getElementById(URI_WHITEBOX);
 		Object motherBoard = element.getProperty("eg:motherBoard", context);
-		System.out.println(motherBoard.getClass());
 		assertTrue("motherBoard has max cardinality of 1 should only have that value returned ",
 			motherBoard instanceof MOF2RDFResource);
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	public void getMotherBoardNoPrefixTest() {
+		loadModelDefaults();
+		RDFResource element = model.getElementById(URI_WHITEBOX);
+		
+		ByteArrayOutputStream errors = new ByteArrayOutputStream();
+		context.setWarningStream(new PrintStream(errors));
+		
+		Collection<MOF2RDFResource> motherBoard = 
+				(Collection<MOF2RDFResource>) element.getProperty("motherBoard", context);
+
+		assertTrue("2 motherboards should have been reported, with no restrictions ", 2 == motherBoard.size());
+
+		String sErrors = errors.toString();
+		assertTrue("An error should be raised Ambiguous property access turning off restriction checks",
+				sErrors.contains("Ambiguous access to property 'motherBoard': No restriction checks applied"));
+ 		
 	}
 
 	@Test

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
@@ -55,58 +55,57 @@ public class MOF2RDFModelOWLReasonerTest {
 	@Test
 	public void getMotherBoardTest() {
 		loadModelDefaults();
+		ByteArrayOutputStream errors = new ByteArrayOutputStream();
+		context.setWarningStream(new PrintStream(errors)); // capture error warnings here
+		
 		RDFResource element = model.getElementById(URI_WHITEBOX);
 		Object motherBoard = element.getProperty("eg:motherBoard", context);
+		
 		assertTrue("motherBoard has max cardinality of 1 should only have that value returned ",
-			motherBoard instanceof MOF2RDFResource);
+			motherBoard instanceof MOF2RDFResource);		
 	}
 	
-	@SuppressWarnings("unchecked")
 	@Test
 	public void getMotherBoardNoPrefixTest() {
 		loadModelDefaults();
-		RDFResource element = model.getElementById(URI_WHITEBOX);
-		
 		ByteArrayOutputStream errors = new ByteArrayOutputStream();
 		context.setWarningStream(new PrintStream(errors));
 		
-		Collection<MOF2RDFResource> motherBoard = 
-				(Collection<MOF2RDFResource>) element.getProperty("motherBoard", context);
+		RDFResource element = model.getElementById(URI_WHITEBOX);
+		MOF2RDFResource motherBoard = (MOF2RDFResource) element.getProperty("motherBoard", context);
 
-		assertTrue("2 motherboards should have been reported, with no restrictions ", 2 == motherBoard.size());
+		assertTrue("1 motherboard should have been reported, with warning ", null != motherBoard);
 
 		String sErrors = errors.toString();
-		assertTrue("An error should be raised Ambiguous property access turning off restriction checks",
-				sErrors.contains("No restriction checks applied"));
- 		
+		assertTrue("A warning should be raised for the Ambiguous property access, and the most restrictive Max Cardinality found",
+				sErrors.contains("The list of raw property values has been pruned"));
+		System.err.println(sErrors);
 	}
 
 	@Test
 	public void getPropertyThatDoesNotExistAsNullTest() {
 		loadModelDefaults();
+		
 		RDFResource element = model.getElementById(URI_ALIENBOX51);
 		Object motherBoard = element.getProperty("eg:motherBoard", context);
+		
 		assertNull("URI_ALIENBOX51 computer does not have motherBoard ", motherBoard);
 	}
 
 	@Test
 	public void getMotherBoardTestIssuesWarning() throws IOException {
+		loadModelDefaults();
 		ByteArrayOutputStream errors = new ByteArrayOutputStream();
+		context.setWarningStream(new PrintStream(errors));
+		
+		// This will return only the first motherboard, but we actually have two
+		model.getElementById(URI_BIGNAME42).getProperty("eg:motherBoard", context);
 
-		PrintStream oldErr = System.err;
-		try {
-			System.setErr(new PrintStream(errors));
-			loadModelDefaults();
+		String sErrors = errors.toString();
+		assertTrue("An error should be raised for max cardinality being exceeded",
+			sErrors.contains("has a max cardinality 1, raw property values list contained"));
+		//System.err.println(sErrors);
 
-			// This will return only the first motherboard, but we actually have two
-			model.getElementById(URI_BIGNAME42).getProperty("eg:motherBoard", context);
-
-			String sErrors = errors.toString();
-			assertTrue("An error should be raised for max cardinality being exceeded",
-				sErrors.contains("has a max cardinality 1, raw property values list contained"));
-		} finally {
-			System.setErr(oldErr);
-		}
 	}
 
 	// Functions not tests

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
@@ -77,7 +77,7 @@ public class MOF2RDFModelOWLReasonerTest {
 
 		String sErrors = errors.toString();
 		assertTrue("An error should be raised Ambiguous property access turning off restriction checks",
-				sErrors.contains("Ambiguous access to property 'motherBoard': No restriction checks applied"));
+				sErrors.contains("No restriction checks applied"));
  		
 	}
 

--- a/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
+++ b/tests/org.eclipse.epsilon.emc.rdf.tests/src/org/eclipse/epsilon/emc/rdf/MOF2RDFModelOWLReasonerTest.java
@@ -12,13 +12,13 @@
  ********************************************************************************/
 package org.eclipse.epsilon.emc.rdf;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.util.Collection;
 
 import org.eclipse.epsilon.common.util.StringProperties;
 import org.eclipse.epsilon.eol.exceptions.models.EolModelLoadingException;
@@ -70,14 +70,13 @@ public class MOF2RDFModelOWLReasonerTest {
 		loadModelDefaults();
 		ByteArrayOutputStream errors = new ByteArrayOutputStream();
 		context.setWarningStream(new PrintStream(errors));
-		
+
 		RDFResource element = model.getElementById(URI_WHITEBOX);
 		MOF2RDFResource motherBoard = (MOF2RDFResource) element.getProperty("motherBoard", context);
-
-		assertTrue("1 motherboard should have been reported, with warning ", null != motherBoard);
+		assertNotNull("1 motherboard should have been reported", motherBoard);
 
 		String sErrors = errors.toString();
-		assertTrue("A warning should be raised for the Ambiguous property access, and the most restrictive Max Cardinality found",
+		assertTrue("A warning should be raised for the raw property values exceeding the max cardinality",
 				sErrors.contains("The list of raw property values has been pruned"));
 		System.err.println(sErrors);
 	}
@@ -85,10 +84,8 @@ public class MOF2RDFModelOWLReasonerTest {
 	@Test
 	public void getPropertyThatDoesNotExistAsNullTest() {
 		loadModelDefaults();
-		
 		RDFResource element = model.getElementById(URI_ALIENBOX51);
 		Object motherBoard = element.getProperty("eg:motherBoard", context);
-		
 		assertNull("URI_ALIENBOX51 computer does not have motherBoard ", motherBoard);
 	}
 
@@ -97,15 +94,13 @@ public class MOF2RDFModelOWLReasonerTest {
 		loadModelDefaults();
 		ByteArrayOutputStream errors = new ByteArrayOutputStream();
 		context.setWarningStream(new PrintStream(errors));
-		
+
 		// This will return only the first motherboard, but we actually have two
 		model.getElementById(URI_BIGNAME42).getProperty("eg:motherBoard", context);
 
 		String sErrors = errors.toString();
 		assertTrue("An error should be raised for max cardinality being exceeded",
 			sErrors.contains("has a max cardinality 1, raw property values list contained"));
-		//System.err.println(sErrors);
-
 	}
 
 	// Functions not tests


### PR DESCRIPTION
In the original RDFResource, there is a workaround for the prefix being null, whereby a greedy collection of statements loosely matching is created. If all the statements share a common prefix, then an assumption is made that what the user intended to access has been found. However, if multiple prefixes are found in the collected statements, there is some ambiguity, a warning is given, and the mixture of statements is returned.

**The proposed solution is not to apply restriction checks on MOF2RDF properties when no prefix is provided in the String property.** After exploring options for extracting a prefix from the values returned, the resource or model. These approaches required parsing a URI string, which may not be consistent (there are differences in prefixes seen with Spiderman and OWLDemoData). The use of the URI on the first returned value seemed a promising solution, however, the value returned may not always be an RDFResource with a URI.

A more consistent approach to handling null prefixes for restriction checking in MOF2RDF would require refactoring RDFResource. The null prefix process would need to be separated from `listPropertyValues()`, and when an assumed "prefix" with no ambiguity exists, expose it for restriction checking. This approach would require further investigation to check how appropriate an assumed prefix is for checking for restrictions.

Original RDFResource.java code for resolving null prefix issues.
```
//Returns a filtered list of property Values, with prefixes and raw value handling
protected Collection<Object> listPropertyValues(RDFQualifiedName propertyName, IEolContext context, LiteralMode literalMode) {
ExtendedIterator<Statement> itStatements; 
itStatements = RDFPropertyProcesses.getPropertyStatementIterator(propertyName, resource);	
itStatements = RDFPropertyProcesses.filterPropertyStatementsIteratorWithLanguageTag(propertyName, itStatements);

// Build a collection Objects for the rawValues of the Objects for the Properties remaining 
Collection<Object> rawPropertyValues;
if (propertyName.prefix == null) {
	// If no prefix was specified, watch out for ambiguity and issue warning in that case
	ListMultimap<String, Object> values = MultimapBuilder.hashKeys().arrayListValues().build();
	while (itStatements.hasNext()) {
		Statement stmt = itStatements.next();
		values.put(stmt.getPredicate().getURI(),
				convertToModelObject(stmt.getObject()));
	}

	final Set<String> distinctKeys = values.keySet();
	if (distinctKeys.size() > 1) {
		context.getWarningStream().println(String.format(
			"Ambiguous access to property '%s': multiple prefixes found (%s)",
			propertyName,
			String.join(", ", distinctKeys)
		));
	}

	rawPropertyValues = values.values();
} else {
	// Prefix was specified: we don't have to worry about ambiguity
	final List<Object> values = new ArrayList<>();
	while (itStatements.hasNext()) {
		Statement stmt = itStatements.next();
		values.add(convertToModelObject(stmt.getObject()));
	}
	rawPropertyValues = values;
}
```